### PR TITLE
Collisions: Intersections (Bounds)

### DIFF
--- a/anm.player.js
+++ b/anm.player.js
@@ -611,6 +611,7 @@ Player.prototype.drawAt = function(time) {
     var ctx = this.ctx,
         state = this.state;
     ctx.clearRect(0, 0, state.width, state.height);
+    this.anim.reset();
     this.anim.render(ctx, time, state.zoom);
     if (this.controls) {
         this.controls.render(state, time);
@@ -1299,6 +1300,8 @@ Element.prototype.reset = function() {
     s.sx = 1; s.sy = 1;
     s.p = null; s.t = null; s.key = null;
     this.__lastJump = null;
+    s._applied = false;
+    s._appliedAt = null;
     s._matrix.reset();
     //this.__clearEvtState();
     this.visitChildren(function(elm) {
@@ -1454,6 +1457,8 @@ Element.prototype.__callModifiers = function(order, ltime) {
         this.__mafter(type, true);
     }
     this.__modifying = null;
+    this._state._applied = true;
+    this._state._appliedAt = ltime;
 
     this.__clearEvts(this._state);
 
@@ -1512,9 +1517,9 @@ Element.prototype.__mbefore = function(type) {
     }*/
 }
 Element.prototype.__mafter = function(type, result) { 
-    if (!result || (type === Element.USER_MOD)) {
+    /*if (!result || (type === Element.USER_MOD)) {
         this.__lmatrix = Element._getIMatrixOf(this.state);
-    }
+    }*/
     /*if (!result || (type === Element.EVENT_MOD)) {
         this.__clearEvtState();
     }*/

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -157,6 +157,23 @@ for (var i = 0; i < 8; i++) {
 var cvselm = document.getElementById('my-canvas');
 return root.move([ (cvselm.width / 2) - (size),
                    (cvselm.height / 2) - (size/2) ]);
+
+var circleOne = b().circle([0, 0], 30).trans([0, 3],
+                                             [[0, 0],
+                                              [400, 400]])
+    .modify(function(t) {
+        var isects = this.$.intersects(circleTwo.v);
+        if (isects) console.log(t, 'circle one intersects circle two');
+        circleOne.fill(isects ? '#0f0' : '#ccc');
+    });
+var circleTwo = b().circle([0, 0], 50).trans([0, 3],
+                                             [[400, 400],
+                                              [0, 0]])
+    .modify(function(t) {
+        var isects = this.$.intersects(circleOne.v);
+        if (isects) console.log(t, 'circle two intersects circle one');
+        circleTwo.fill(isects ? '#f00' : '#ccc');
+    });
 */
 
 var uexamples = [];


### PR DESCRIPTION
now `intersects(elm[, t])` test works for bounds-mode, here's the test:

```
var circleOne = b('c1').circle([0, 0], 30)
                       .trans([0, 3], [[0, 200], [400, 200]])
    .modify(function(t) {
        var isects = this.$.intersects(circleTwo.v);
        if (isects) console.log(t, 'circle one intersects circle two');
        circleOne.fill(isects ? '#0f0' : '#ccc');
    });
var circleTwo = b('c2').circle([0, 0], 50)
                       .trans([0, 3], [[400, 200], [0, 200]])
    .modify(function(t) {
        var isects = this.$.intersects(circleOne.v);
        if (isects) console.log(t, 'circle two intersects circle one');
        circleTwo.fill(isects ? '#f00' : '#ccc');
    });

return b().add(circleOne).add(circleTwo);
```

Additions:
- fix incorrect bounds-checks
- fix not resetting scene when calling drawAt
- fix checking contains/intersects with not-initialized state 
