### PR TITLE
Friday fixes

### DIFF
--- a/anm.builder.js
+++ b/anm.builder.js
@@ -134,6 +134,7 @@ Builder.prototype.circle = function(pt, radius) {
     this.x.pos = pt;
     this.x.reg = [ 0, 0 ];
     var b = this;
+    this.x.__bounds = [ 0, 0, radius*2, radius*2];
     this.paint(function(ctx) {
         DU.qDraw(ctx, b.s, b.f,
                  function() {
@@ -170,8 +171,7 @@ Builder.prototype.text = function(pt, lines, size, font) {
     var text = lines instanceof Text ? lines
                      : new Text(lines, Builder.font(font, size));
     this.x.text = text;
-    var dimen = text.dimen();
-    this.x.reg = [ dimen[0] / 2, dimen[1] / 2];
+    this.x.reg = [ 0, 0 ];
     if (!text.stroke) { text.stroke = this.s; }
     else { this.s = text.stroke; }
     if (!text.fill) { text.fill = this.f; }
@@ -228,6 +228,32 @@ Builder.prototype.reg = function(pt) {
     x.reg = pt;
     return this;
 }
+C.R_TL = 1; C.R_TC = 5; C.R_TR = 2;
+C.R_ML = 6; C.R_MC = 0; C.R_MR = 7;
+C.R_BL = 3; C.R_BC = 8; C.R_BR = 4;
+// > builder.reg % (side: C.R_*) => Builder
+Builder.prototype.regAt = function(side) {
+    var x = this.x, _new = x.reg;
+    var b = this.v.lbounds();
+    if (!b) return this; // throw error?
+    var w = b[2] - b[0],
+        h = b[3] - b[1];
+    switch (side) {
+        case C.R_TL: _new = [ -w/2, -h/2 ]; break;
+        case C.R_TC: _new = [    0, -h/2 ]; break;
+        case C.R_TR: _new = [  w/2, -h/2 ]; break;
+
+        case C.R_ML: _new = [ -w/2,    0 ]; break;
+        case C.R_MC: _new = [    0,    0 ]; break;
+        case C.R_MR: _new = [  w/2,    0 ]; break;
+
+        case C.R_BL: _new = [ -w/2,  h/2 ]; break;
+        case C.R_BC: _new = [    0,  h/2 ]; break;
+        case C.R_BR: _new = [  w/2,  h/2 ]; break;
+    } 
+    x.reg = _new;
+    return this;
+}
 // > builder.move % (pt: Array[2,Integer]) => Builder
 Builder.prototype.move = function(pt) {
     var x = this.x;
@@ -241,6 +267,12 @@ Builder.prototype.zoom = function(val) {
         this.x.path.zoom(val);
         this.path(this.x.path); // will normalize it
     }
+    return this;
+}
+// > builder.bounds % (val: Array[4,Float]) => Builder
+Builder.prototype.bounds = function(bounds) {
+    if (!bounds.length === 4) throw new Error('Incorrect bounds');
+    this.x.__bounds = bounds;
     return this;
 }
 

--- a/anm.player.js
+++ b/anm.player.js
@@ -1406,13 +1406,14 @@ Element.prototype.global = function(pt) {
 }*/
 Element.prototype.lbounds = function() {
     var x = this.xdata;
+    if (x.__bounds) return x.__bounds;
     var bounds;
     if (x.path) {
         bounds = x.path.bounds();
     } else if (x.image) {
         bounds = [ 0, 0, x.image.width, x.image.height ];
     } else if (x.text) {
-        bound = x.text.bounds();
+        bounds = x.text.bounds();
     } else return null;
     return bounds;
 }
@@ -2939,7 +2940,8 @@ Text.prototype.apply = function(ctx, point) {
     var point = point || [0, 0],
         dimen = this.dimen(),
         accent = this.accent(dimen[1]),
-        apt = [ point[0], point[1] + accent];
+        apt = [ point[0] - dimen[0]/2, 
+                point[1] + accent - dimen[1]/2];
     ctx.font = this.font;
     ctx.textBaseline = Text.BASELINE_RULE;
     if (this.fill) {

--- a/doc/API.md
+++ b/doc/API.md
@@ -663,7 +663,9 @@ As in difference with [Tweens](#tweens), sometimes you need to "correct" the sta
 
 > ♦ `builder.reg % (pt: Array[2,Integer]) => Builder`
 
-This method changes the registration point position of the shape, this point affects tweens, so the rotation will be performed around this point, translation will be shifted with this point and so on. This point needs to be specified relative to the previous registration point of the shape. Use ['debug' mode](#player-options) of the player to see the registrations points of the shapes.
+This method changes the registration point position of the shape, this point affects tweens, so the rotation will be performed around this point, translation will be shifted with this point and so on. This point needs to be specified relative to the center of the shape. Use ['debug' mode](#player-options) of the player to see the registrations points of the shapes.
+
+<!-- TODO: regAt & its constants (not works for circle) -->
 
     b().cilcle([ 20, 20 ], 60).reg([ -10, -10 ]);
 


### PR DESCRIPTION
- Fixed handling key events (autofocusing + `tabindex`)
- Fix for text registration point to be in center
- `_checkMode()` method improved to be easily called after mode change and work then
- `regAt()` method for `Builder` to easily position registration point
-  Allow to override bounds
- A bit more docs
