### PR TITLE
From 0.23 bugfixes: Fix Issue in children cloning

### DIFF
--- a/anm.player.js
+++ b/anm.player.js
@@ -1444,10 +1444,21 @@ Element.prototype.clone = function() {
     clone._painters = this._painters.slice(0);
     clone.xdata = obj_clone(this.xdata);
     clone.xdata.$ = clone;
+    clone.__data = this.__data;
     return clone;
 }
 Element.prototype.dclone = function() {
     var clone = this.clone();
+    clone.children = [];
+    var src_children = this.children;
+    var trg_children = clone.children;
+    for (var sci = 0, scl = src_children.length; sci < scl; sci++) {
+        var csrc = src_children[sci],
+            cclone = csrc.dclone();
+        cclone.parent = clone;
+        trg_children.push(cclone);
+    }
+    clone.__data = obj_clone(this.__data); 
     var src_x = this.xdata,
         trg_x = clone.xdata;
     if (src_x.path) trg_x.path = src_x.path.clone();

--- a/doc/API.md
+++ b/doc/API.md
@@ -433,27 +433,30 @@ Every `Builder` instance have five public properties: `v`, `n`, `x` and `f`, `s`
     
 When you have an instance of `Builder`, it is just the prepared state of some [shape](#shapes): path, image, or text. It becomes dynamic when you add [tweens](#tweens) and/or [modifiers](#modifiers) to it. But it is still just prepared dynamic condition — to make it play, you need to pass (load) it into player. This is when system appends all required functionality to it, allows it to act. The same is true for [Element](#element-reference). Of course, you don't need to add every Builder/Element, it happens automatically for the complete scene tree when you load it into player. See [Scene](#scene) section for more information on this, if you want. 
 
-**NB:** Cloning (the last one in the list) is a very tasty feature, but you need to be very accurate with it. Among with element internals it clones its children array, but not deep-clones. So, if you create a recursive scene, be accurate with things like this:
+**NB:** Cloning (the last one in the list) is a very tasty feature, but you need to be very accurate with it. Among with element internals it deeply-clones its children array. So, if you create a recursive scene, be accurate with things like this:
 
     var c = b().circle([0, 0], 20);
+    // var scene = c;
     for (var i = 0; i < 30; i++) {
         c.add(b(c).move([10, 10])); // will add 30x30 children to tree 
     } // this will end up with hanging player
     
     // safe way with nesting:
     var c = b().circle([0, 0], 20);
+    // var scene = c;
     for (var i = 0; i < 30; i++) {
         c.add(c = b(c).move([10, 10])); // will nest every new child a level below
     }
     
     // safe way with 30 children:
     var c = b().circle([0, 0], 20);
+    // var scene = c;
     var clone = b(c);
     for (var i = 0; i < 30; i++) {
-        c.add(b(clone).move([i*10, i*10])); // add new clone 
+        c.add(b(clone).move([i*10, i*10])); // add new clone, all children are on the same level
     }
 
-**NB:** `Builder._$(...)`/`b(...)` function differs from `new Builder(...)` call — if `Element` is passed there, it checks if there was one created for this element already, and instantiates _new_ `Builder` only if not, else it returns the cached one. Cloning is cloning however, so if there is a `Builder` passed, it honestly creates a clone.
+**NB:** `Builder._$(...)`/`b(...)` function differs from `new Builder(...)` call — if `Element` is passed to the first one, it checks if there was one created for this element already, and instantiates _new_ `Builder` only if not, else it returns the cached one. Cloning is cloning however, so if there is a `Builder` passed, it honestly creates a clone in both cases.
 
 ### Structures
 
@@ -1149,7 +1152,7 @@ Also you may set a name to some frame using `key()` function and jump to it with
 
 > ♦ `builder.take % (b: Builder) => Builder`
 
-Make the given `Builder` to be the source of the data for current `Builder`, its contents pointers will be copied so any changes of fill, stroke, path, text, shape will apply to both instances:
+Make the given `Builder` to be the source of the data for current `Builder`, its contents pointers will be copied so any changes of fill, stroke, path, text, shape will apply to both instances (the same for children, they are not cloned, but pointers to them are copied):
 
     var src = b().rect([40, 40], 20).fill('#006');
     var clone = b().take(src).fill('#f06').move([70, 70]);
@@ -1157,7 +1160,7 @@ Make the given `Builder` to be the source of the data for current `Builder`, its
 
 > ♦ `builder.use % (b: Builder) => Builder`
 
-Use the given `Builder`  to make a clone of the data for this `Builder`, all its contents will be cloned so it will be the separate object, but with the same content:
+Use the given `Builder`  to make a clone of the data for this `Builder`, all its contents, including children, will be cloned so it will be the separate object, but with the same content:
 
     var src = b().rect([40, 40], 20).fill('#006');
     var clone = b().use(src).fill('#f06').move([70, 70]);


### PR DESCRIPTION
Relates to [`another_cloning_problem`](https://github.com/Nek/Chain-Reaction/tree/another_cloning_problem) tag in [Nek.Chain-Reaction](https://github.com/Nek/Chain-Reaction) game:

Colors of the circles were not cloned and click/contains tests failed to check point correctly when `var newLevel = b(level)` line was called (see [L227](https://github.com/Nek/Chain-Reaction/blob/another_cloning_problem/index.html#L227)). It was a complicate one, despite the fix looks tiny.

The reasons/fixes:
- When cloned, every child (circle thing) of the level kept the `parent` pointer pointing to the source level, which was never drawn and so had no state/matrix -> coordinates were converted to global space incorrectly, so contains failed to work. Now `parent` link is updated to point to new clone when cloning, for children (not for the cloned element, because cloning means detaching from the tree).
- Circle drawing problem. A painter of a circle uses `builder.f` (fill) and `builder.s` (stroke) properties to draw an arc with current color, and it saved a pointer to source builder to update them if they were changed. These properties are stored only in Builder instance in case of circle (for other shapes they are stored as as `xdata.path` properties). However:
  - The 'template' circle was cloned to produce other circles with different random fill, so builder pointer from a closure became invalid in each case. Now I store a link to builder in the element itself.
  - Then, they were cloned as a children of a level. When a cloning like this happens, only elements' instances are appended to the clone as children, not the builders that wrapped them (however, if there were no previous case, closure pointer to builder should be saved inside painter anyway, physically builders were not lost). It was also solved with keeping a link (and copying it with the clone operation) to builder instance in the element, and using it in painter.
