### PR TITLE
Fix serious mistype in calculating priority + replacing removed modifiers/painters with null

### DIFF
--- a/anm.player.js
+++ b/anm.player.js
@@ -1287,13 +1287,13 @@ Element.prototype.addModifier = function(modifier, data, priority) {
 }
 // > Element.removeModifier % (id: Integer)
 Element.prototype.removeModifier = function(id) {
-    if (this.__modifying) throw new Error("Can't remove modifiers while modifying");
+    //if (this.__modifying) throw new Error("Can't remove modifiers while modifying");
     var TB = Element.TYPE_MAX_BIT,
         PB = Element.PRRT_MAX_BIT;
     var type = id >> TB,
-        priority = id - (type << TB),
+        priority = (id - (type << TB)) >> PB,
         i = id - (type << TB) - (priority << PB);
-    this._modifiers[type][priority].splice(i, 1);
+    this._modifiers[type][priority][i] = null;
 }
 // > Element.addPainter % (painter: Function(ctx: Context))
 //                         => Integer
@@ -1302,13 +1302,13 @@ Element.prototype.addPainter = function(painter, data, priority) {
 }
 // > Element.removePainter % (id: Integer)
 Element.prototype.removePainter = function(id) {
-    if (this.__painting) throw new Error("Can't remove painters while painting");
+    //if (this.__painting) throw new Error("Can't remove painters while painting");
     var TB = Element.TYPE_MAX_BIT,
         PB = Element.PRRT_MAX_BIT;
     var type = id >> TB,
-        priority = id - (type << TB),
+        priority = (id - (type << TB)) >> PB,
         i = id - (type << TB) - (priority << PB);
-    this._painters[type][priority].splice(i, 1);
+    this._painters[type][priority][i] = null;
 }
 // > Element.addTween % (tween: Tween)
 Element.prototype.addTween = function(tween) {


### PR DESCRIPTION
Fix serious mistype in calculating priority + replacing removed modifiers/painters with `null` to make removing stable.

Full example:

``` javascript
var redRect = b('red-rect').rect([115, 90], [60, 60])
                 .fill('#f00');

var dx = redRect.modify(function(t) { this.x += 3; }).get_m_id();
var dx2 = redRect.modify(function(t) { this.x += 3; }).get_m_id();
var dy = redRect.modify(function(t) { this.y += 6; }).get_m_id();
var da = redRect.modify(function(t) { this.alpha -= 0.01; }).get_m_id();

// comment / uncomment the lines below to see the effect
//redRect.unmodify(da);
redRect.unmodify(dx);
redRect.unmodify(dx2);
redRect.unmodify(dy);

return b()
  .add(
   b('blue-rect').rect([140, 25], [70, 70])
                  .fill('#009')
                  .stroke('#f00', 3)
                  .rotate([0, 10], [0, Math.PI / 2]))
  .add(redRect)
  .rotate([0, 10], [0, Math.PI]);
```
