### PR TITLE
Tune player with data-attrs

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -22,6 +22,12 @@
     <script src="./rel/alpha_project.js" type="text/javascript"></script>
     <!-- <script src="./rel/draw_tiger.js" type="text/javascript"></script> -->
 
+    <style type="text/css">
+      #__canvas1_info {
+        color: #f00;
+      }
+    </style>
+
     <script type="text/javascript">
       function start() {
           var b = Builder._$, C = anm.C;
@@ -105,7 +111,8 @@ var scene1 = b().rect([100, 70], [70, 70])
                 .stroke('#f00', 3);
 createPlayer('canvas1').load(scene1);
     </code></pre>
-    <canvas id="canvas1"></canvas>
+    <canvas id="canvas1"  data-title="Rectangles"></canvas>
+    <!-- <canvas id="canvas1"  data-title="Rectangles" data-bgcolor="rgba(30, 30, 30, 0.4)"></canvas> -->
 
     <!-- canvas2 -->
 
@@ -118,7 +125,7 @@ var scene2 = b().add(b('blue-rect').rect([140, 25], [70, 70])
                 .rotate([0, 10], [0, Math.PI]);
 createPlayer('canvas2').load(scene2);
     </code></pre>
-    <canvas id="canvas2" data-bgcolor="rgba(30, 30, 30, 0.8)"></canvas>
+    <canvas id="canvas2" data-title="Rectangles-2"></canvas>
 
     <!-- canvas3 -->
 
@@ -130,7 +137,7 @@ p3.debug = true;
 p3.load(demo_project, importer);
 p3.play(6);
     </code></pre>
-    <canvas id="canvas3"></canvas>
+    <canvas id="canvas3" width="1000" height="500"></canvas>
 
     <!-- canvas4 -->
 
@@ -138,7 +145,7 @@ p3.play(6);
     <pre><code>
 createPlayer('canvas4').load(rectangles_project, new AnimatronImporter());
     </code></pre>
-    <canvas id="canvas4"></canvas>
+    <canvas id="canvas4" data-height="500" data-width="700"></canvas>
 
     <!-- canvas5 -->
 


### PR DESCRIPTION
It is now available to configure some options of the player with `data-`attributes directly from canvas. None are required, any is optional:

``` html
<canvas id="my-canvas" data-width="400" data-height="800"
        data-author="Me" data-title="My Work" 
        data-bgcolor="rgba(255, 0, 0, 0.5)" data-debug="true"></canvas>
```

`data-width`/`data-height` are the same as `width`/`height`, so the later ones are preferred. 
