### PR TITLE
A callback to call after every frame + some nice playing cycle/drawAt tests

### DIFF
--- a/anm.player.js
+++ b/anm.player.js
@@ -707,7 +707,7 @@ Player.prototype.configureMeta = function(info) {
 Player.prototype.drawAt = function(time) {
     if (time === Player.NO_TIME) throw new Error('Given time is not allowed, it is treated as no-time');
     if ((time < 0) || (time > this.state.duration)) {
-        throw new Error('Passed time is not in scene range');
+        throw new Error(Player.PASSED_TIME_NOT_IN_RANGE_ERR);
     }
     var ctx = this.ctx,
         state = this.state;
@@ -717,6 +717,10 @@ Player.prototype.drawAt = function(time) {
     if (this.controls) {
         this._renderControlsAt(time);
     }
+}
+Player.prototype.afterFrame = function(callback) {
+    if (this.state.happens === C.PLAYING) throw new Error(Player.AFTERFRAME_BEFORE_PLAY_ERR);
+    this.__userAfterFrame = callback;
 }
 Player.prototype.detach = function() {
     if (this.controls) this.controls.detach(this.canvas);
@@ -919,22 +923,25 @@ Player.prototype._ensureAnim = function() {
     if (!this.anim) throw new Error(Player.NO_SCENE_ERR);
 }
 Player.prototype.__afterFrame = function(scene) {
-    return (function(player, state, scene) { return function(time) {
-        if (state.happens !== C.PLAYING) return false;
-        if (time > (state.duration + Player.PEFF)) {
-            state.time = 0;
-            scene.reset();
-            player.stop();
-            if (state.repeat) {
-               player.play();
+    return (function(player, state, scene, callback) {
+        return function(time) {
+            if (state.happens !== C.PLAYING) return false;
+            if (time > (state.duration + Player.PEFF)) {
+                state.time = 0;
+                scene.reset();
+                player.stop();
+                if (state.repeat) {
+                   player.play();
+                }
+                return false;
             }
-            return false;
+            if (player.controls) {
+                player._renderControls();
+            }
+            if (callback) callback(time);
+          return true;
         }
-        if (player.controls) {
-            player._renderControls();
-        }
-        return true;
-    }})(this, this.state, scene);
+    })(this, this.state, scene, this.__userAfterFrame);
 }
 
 Player.prototype.__originateErrors = function() {
@@ -3768,6 +3775,8 @@ Player.NO_SCENE_ERR = 'There\'s nothing at all to manage with, ' +
 Player.COULD_NOT_LOAD_WHILE_PLAYING_ERR = 'Could not load any scene while playing or paused, ' +
                       'please stop player before loading';
 Player.UNSAFE_TO_REMOVE_ERR = 'Unsafe to remove, please use iterator-based looping (with returning false from iterating function) to remove safely';
+Player.AFTERFRAME_BEFORE_PLAY_ERR = 'Please assign afterFrame callback before calling play()';
+Player.PASSED_TIME_NOT_IN_RANGE_ERR = 'Passed time is not in scene range';
 
 // =============================================================================
 // === EXPORTS =================================================================

--- a/tests/anm.matchers.js
+++ b/tests/anm.matchers.js
@@ -27,7 +27,7 @@ matchers.toHaveBeenCalledOnce = function() {
     return (this.actual.calls.length === 1);
 };
 
-// TODO: remove, just check call count
+// FIXME: replace with expect(spy.callCount).toBe(num)
 matchers.toHaveBeenCalledThisAmountOfTimes = function(num) {
 
     //if (!num) throw new Error('Use .not.toHaveBeenCalled');
@@ -68,6 +68,19 @@ matchers.toBeGreaterThanOrEqual = function(expected) {
     };
 
     return actual >= expected;
+}
+
+matchers.toBeEpsilonyCloseTo = function(expected, epsilon) {
+    var actual = this.actual;
+    var notText = this.isNot ? " not" : "";
+
+    this.message = function () {
+        return "Expected " + actual + notText + " to be greater than or equal to " +
+               (expected - epsilon) + " and less or equal to " + (expected + epsilon);
+    };
+
+    return (actual >= (expected - epsilon)) && (actual <= (expected + epsilon));
+
 }
 
 return matchers;


### PR DESCRIPTION
Use `player.afterFrame(function(t) { .... })` to assign.

You may do it any every moment while not playing, when starting to play — it is applied.
