### PR TITLE
Improved removing modifiers/painters

### DIFF
--- a/anm.builder.js
+++ b/anm.builder.js
@@ -302,7 +302,7 @@ Builder.prototype.tween = function(type, band, data, easing) {
         aeasing = (easing && (typeof easing === 'function'))
                   ? { f: function() { return easing; }, data: null }
                   : aeasing;
-    this.__m_id = this.v.addTween({
+    this.v.addTween({
         type: type,
         band: band,
         data: data,
@@ -310,9 +310,7 @@ Builder.prototype.tween = function(type, band, data, easing) {
     });
     return this;
 }
-// > builder.get_t_id % () => Integer
-Builder.prototype.get_t_id = Builder.prototype.get_m_id;
-// > builder.untween % (id: Integer) => Builder
+// > builder.untween % (tween: Function) => Builder
 Builder.prototype.untween = Builder.prototype.unmodify;
 // > builder.rotate % (band: Array[2,Float],
 //                     angles: Array[2,Float],
@@ -389,14 +387,14 @@ Builder.prototype.bounce = function() {
 //                                        data: Any),
 //                     [data: Any, priority: Integer]) => Builder
 Builder.prototype.modify = function(func, data, priority) {
-    this.__m_id = this.v.addModifier(func, data, priority);
+    this.v.addModifier(func, data, priority);
     return this;
 }
 // > builder.paint % (painter: Function(ctx: Context,
 //                                      data: Any),
 //                    [data: Any, priority: Integer]) => Builder
 Builder.prototype.paint = function(func, data, priority) {
-    this.__p_id = this.v.addPainter(func, data, priority);
+    this.v.addPainter(func, data, priority);
     return this;
 }
 // > builder.at % (t: time, modifier: Function(time: Float,
@@ -404,28 +402,19 @@ Builder.prototype.paint = function(func, data, priority) {
 //                     [data: Any, priority: Integer]) => Builder
 Builder.prototype.at = function(t, func, data, priority) {
     var me = this;
-    var at_id = me.modify(function(real_t, data) {
-        if (real_t >= t) { func.call(this, real_t, data); me.unmodify(at_id); }
-    }, data, priority).get_m_id();
+    var m_at = function(real_t, data) {
+        if (real_t >= t) { func.call(this, real_t, data); me.unmodify(m_at); }
+    };
+    me.modify(m_at, data, priority);
 }
-// > builder.get_m_id % () => Integer
-Builder.prototype.get_m_id = function() {
-    if (typeof this.__m_id === 'undefined') throw new Error('No modifiers were added before');
-    return this.__m_id;
-}
-// > builder.get_p_id % () => Integer
-Builder.prototype.get_p_id = function() {
-    if (typeof this.__p_id === 'undefined') throw new Error('No painters were added before');
-    return this.__p_id;
-}
-// > builder.unmodify % (id: Integer) => Builder
-Builder.prototype.unmodify = function(id) {
-    this.v.removeModifier(id);
+// > builder.unmodify % (modifier: Function) => Builder
+Builder.prototype.unmodify = function(modifier) {
+    this.v.removeModifier(modifier);
     return this;
 }
-// > builder.unpaint % (id: Integer) => Builder
-Builder.prototype.unpaint = function(id) {
-    this.v.removePainter(id);
+// > builder.unpaint % (painter: Function) => Builder
+Builder.prototype.unpaint = function(painter) {
+    this.v.removePainter(painter);
     return this;
 }
 
@@ -456,12 +445,10 @@ Builder.prototype.tease = function(ease) {
 
 // > builder.on % (type: String, handler: Function(evt: Event, t: Float)) => Builder
 Builder.prototype.on = function(type, handler) {
-    this.__m_id = this.v.m_on(type, handler);
+    this.v.m_on(type, handler);
     return this;
 }
-// > builder.get_h_id % () => Integer
-Builder.prototype.get_h_id = Builder.prototype.get_m_id;
-// > builder.unhandle % (id: Integer) => Builder
+// > builder.unhandle % (handler: Function) => Builder
 Builder.prototype.unhandle = Builder.prototype.unmodify;
 
 // * TAKE & USE *

--- a/doc/API.md
+++ b/doc/API.md
@@ -1092,7 +1092,29 @@ To add painter function to a shape, use `paint()` method. This function gets can
 
 As for modifiers, you may optionally pass `data` object of any type, and it will be passed to your painter as second parameter every time it will be called. And again, you may specify a priority number — the higher this number, the later this painter will be called in the painters sequence. The painters with the same priority will be called in the order of addition. Also, there is a link to current element (painter owner) as `this.$`, but we hope (and we will try to make it so) you will need it only in rare cases.
 
-> We strongly recommend to use prefixes in the names of your Modifiers/Painters/Handlers if they are prepared before, so you'd easy distinguish what is what even if you have a lot of code. We use `m_`, `p_` and `h_` correspondingly.
+> We strongly encourage you to use prefixes in the names of your Modifiers/Painters/Handlers if they are prepared before, so you'd easy distinguish what is what even if you have a lot of code. We use `m_`, `p_` and `h_` correspondingly.
+
+#### Removing modifiers or painters
+
+> ♦ `builder.unmodify % (modifier: Function) => Builder`
+
+This method will remove previously added modifier from the element, in the way like:
+
+    var m_temp = function(t) {...};
+    var my_elm = b();
+    my_elm.modify(m_temp);
+    ...
+    my_elm.unmodify(m_temp);
+
+> ♦ `builder.unpaint % (painter: Function) => Builder`
+
+This method will remove previously added painter from the element, in the way like:
+
+    var p_temp = function(ctx) {...};
+    var my_elm = b();
+    my_elm.paint(p_temp);
+    ...
+    my_elm.unpaint(p_temp);
 
 ### Events
 

--- a/tests/spec/02.animations/stub.spec.js
+++ b/tests/spec/02.animations/stub.spec.js
@@ -5,9 +5,9 @@
  * Animatron player is licensed under the MIT License, see LICENSE.
  */
 
-describe("stub spec", function() {
+xdescribe("stub spec", function() {
 
-    it("should be stubby", function() {
+    xit("should be stubby", function() {
         expect(true).toBeTruthy();
     });
 

--- a/tests/spec/04.builder/01.formation.spec.js
+++ b/tests/spec/04.builder/01.formation.spec.js
@@ -423,21 +423,21 @@ describe("builder, regarding its formation techniques,", function() {
 
                 var mod_four = _mocks.factory.nop(),
                     mod_five = _mocks.factory.nop();
-                var m_four_id = to_clone.modify(mod_four).get_m_id(),
-                    m_five_id = to_clone.modify(mod_five).get_m_id();
+                to_clone.modify(mod_four);
+                to_clone.modify(mod_five)
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0].length).toBe(4);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0].length).toBe(3);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0][2][0]).toBe(mod_four);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0][3][0]).toBe(mod_five);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0][2][0]).toBe(mod_three);
-                to_clone.unmodify(m_four_id);
+                to_clone.unmodify(mod_four);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0].length).toBe(4);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0].length).toBe(3);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0][2]).toBe(null);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0][3][0]).toBe(mod_five);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0][2]).not.toBe(null);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0][2][0]).toBe(mod_three);
-                to_clone.unmodify(m_five_id);
+                to_clone.unmodify(mod_five);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0].length).toBe(4);
                 expect(instance.v._modifiers[anm.Element.USER_MOD][0].length).toBe(3);
                 expect(to_clone.v._modifiers[anm.Element.USER_MOD][0][2]).toBe(null);
@@ -471,21 +471,21 @@ describe("builder, regarding its formation techniques,", function() {
 
                 var pnt_four = _mocks.factory.nop(),
                     pnt_five = _mocks.factory.nop();
-                var p_four_id = to_clone.paint(pnt_four).get_p_id(),
-                    p_five_id = to_clone.paint(pnt_five).get_p_id();
+                to_clone.paint(pnt_four);
+                to_clone.paint(pnt_five);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0].length).toBe(4);
                 expect(instance.v._painters[anm.Element.USER_PNT][0].length).toBe(3);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0][2][0]).toBe(pnt_four);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0][3][0]).toBe(pnt_five);
                 expect(instance.v._painters[anm.Element.USER_PNT][0][2][0]).toBe(pnt_three);
-                to_clone.unpaint(p_four_id);
+                to_clone.unpaint(pnt_four);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0].length).toBe(4);
                 expect(instance.v._painters[anm.Element.USER_PNT][0].length).toBe(3);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0][2]).toBe(null);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0][3][0]).toBe(pnt_five);
                 expect(instance.v._painters[anm.Element.USER_PNT][0][2]).not.toBe(null);
                 expect(instance.v._painters[anm.Element.USER_PNT][0][2][0]).toBe(pnt_three);
-                to_clone.unpaint(p_five_id);
+                to_clone.unpaint(pnt_five);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0].length).toBe(4);
                 expect(instance.v._painters[anm.Element.USER_PNT][0].length).toBe(3);
                 expect(to_clone.v._painters[anm.Element.USER_PNT][0][2]).toBe(null);

--- a/tests/spec/04.builder/06.tweens.spec.js
+++ b/tests/spec/04.builder/06.tweens.spec.js
@@ -1,0 +1,1 @@
+// TODO: test untweening

--- a/tests/spec/04.builder/08a.modifiers.spec.js
+++ b/tests/spec/04.builder/08a.modifiers.spec.js
@@ -327,14 +327,11 @@ describe("builder, regarding modifiers", function() {
         it("should support removing modifiers", function() {
             scene = b('scene').band([0, 1]);
 
-            var modifierId;
-
             var modifierSpy = jasmine.createSpy('modifier-spy').andCallFake(function(t) {
                 expect(t).toBeGreaterThanOrEqual(0);
                 if (t > .5) {
-                    expect(modifierId).toBeDefined();
-                    expect(!isNaN(modifierId)).toBeTruthy(); // ensure modifier id is a number
-                    scene.unmodify(modifierId);
+                    expect(modifierSpy).toHaveBeenCalled();
+                    scene.unmodify(modifierSpy);
                     modifierSpy.reset();
                     return;
                 }
@@ -343,7 +340,7 @@ describe("builder, regarding modifiers", function() {
             });
 
             runs(function() {
-                modifierId = scene.modify(modifierSpy).get_m_id();
+                scene.modify(modifierSpy);
                 player.load(scene).play();
             });
 
@@ -362,32 +359,29 @@ describe("builder, regarding modifiers", function() {
             scene = b('scene').band([0, 1]);
 
             var modifierSpies = [];
-            var modifiersIds = [];
             var spiesCount = 10;
 
             for (var i = 0; i < spiesCount; i++) {
-                modifierSpies.push(jasmine.createSpy('modifier-spy-'+i).andCallFake(
-                    (function(i) { return function(t, removeTime) {
+                modifierSpies.push(jasmine.createSpy('modifier-spy-'+i).andCallFake((function(i) {
+                    return function(t, removeTime) {
                         expect(t).toBeGreaterThanOrEqual(0);
                         if (t > removeTime) {
-                            var modifierId = modifiersIds[i];
+                            var modifier = modifierSpies[i];
                             expect(removeTime).toEqual(i !== 0 ? ((1 / i) - .1) : 0);
-                            expect(modifierId).toBeDefined();
-                            expect(!isNaN(modifierId)).toBeTruthy(); // ensure modifier id is a number
-                            scene.unmodify(modifierId);
+                            expect(modifier).toHaveBeenCalled();
+                            scene.unmodify(modifier);
                             modifierSpies[i].reset();
                             return;
                         }
                         // if modifier wasn't self-removed, time should be less than .5
                         expect(t).toBeLessThanOrEqual(removeTime);
-                    } })(i)
-                ));
+                    } })(i)));
             };
 
             runs(function() {
                 for (var i = (spiesCount - 1); i >= 0; i--) {
-                    modifiersIds[i] = scene.modify(modifierSpies[i],
-                                            i !== 0 ? ((1 / i) - .1) : 0).get_m_id();
+                    scene.modify(modifierSpies[i],
+                                 i !== 0 ? ((1 / i) - .1) : 0);
                 }
                 player.load(scene).play();
             });
@@ -404,6 +398,11 @@ describe("builder, regarding modifiers", function() {
             });
 
         });
+
+        // TODO: ensure removing fails if modifier wasn't added to element
+        // TODO: test that modifier added to some element, which then was cloned, may be easily removed from the last
+        // TODO: test that error is fired if modifier was already added to this element
+        // TODO: test adding one modifier to several elements and removing it then
 
     });
 

--- a/tests/spec/05.collisions/stub.spec.js
+++ b/tests/spec/05.collisions/stub.spec.js
@@ -5,9 +5,9 @@
  * Animatron player is licensed under the MIT License, see LICENSE.
  */
 
-describe("stub spec", function() {
+xdescribe("stub spec", function() {
 
-    it("should be stubby", function() {
+    xit("should be stubby", function() {
         expect(true).toBeTruthy();
     });
 


### PR DESCRIPTION
An improvement that lets user remove modifiers/painters easier. Compare:

Before:

``` javascript
var elm = b();
m_to_remove = elm.modify(function(t) { ... }).get_m_id();
// (impossible to chain calls after get_m_id since it stops the chain)
...
elm.unmodify(m_to_remove);

var elm = b();
p_to_remove = elm.paint(function(ctx) { ... }).get_p_id();
// (impossible to chain calls after get_p_id since it stops the chain)
...
elm.unpaint(p_to_remove);
```

Now:

``` javascript
var elm = b();
function m_to_remove(t) { ... };
elm.modify(m_to_remove)/*.modify(...).band(....)*/;
...
elm.unmodify(m_to_remove);

var elm = b();
function p_to_remove(ctx) { ... };
elm.paint(p_to_remove)/*.paint(...).band(....)*/;
...
elm.unpaint(p_to_remove);
```

Now pre-calculated id is stored in modifier/painter itself, and it is stored for every element it was attached to.

Cloning also should work properly. And `untween` and `unhandle` now work the same way 
