### PR TITLE
Same-type tweens are now overwrite each other

### DIFF
--- a/anm.player.js
+++ b/anm.player.js
@@ -2903,7 +2903,7 @@ Tweens[C.T_TRANSLATE] =
 Tweens[C.T_ALPHA] =
     function() {
       return function(t, duration, data) {
-        this.alpha *= data[0] * (1.0 - t) + data[1] * t;
+        this.alpha = data[0] * (1.0 - t) + data[1] * t;
       };
     };
 Tweens[C.T_SCALE] =

--- a/tests/spec/04.builder/07.tweens.spec.js
+++ b/tests/spec/04.builder/07.tweens.spec.js
@@ -1911,7 +1911,61 @@ describe("tweens", function() {
 
                 describe("single one", function() {
 
-                    describe("will change angle value of the state according to given rotation", function() {
+                    describe("will change alpha value of the state", function() {
+
+                        it("works in case of simple values", function() {
+                            checkTweens([0, 1],
+                                        [ [ 'alpha', [ 0, 1 ], [3, 1] ] ],
+                                        function(s, at) {
+                                            expect(s.alpha).toBeCloseTo((3 * (1.0 - at)) + (1 * at), CLOSE_FACTOR);
+                                        });
+                        });
+
+                        it("works in case of zero", function() {
+                            checkTweens([0, 1],
+                                        [ [ 'alpha', [ 0, 1 ], [8, 0] ] ],
+                                        function(s, at) {
+                                            expect(s.alpha).toBeCloseTo((8 * (1.0 - at)) + (0 * at), CLOSE_FACTOR);
+                                        });
+
+                            // both zero, left zero?
+                        });
+
+                        it("works in case of mixed values (incl. negative)", function() {
+                            checkTweens([0, 1],
+                                        [ [ 'alpha', [ 0, 1 ], [-1, 6] ] ],
+                                        function(s, at) {
+                                            expect(s.alpha).toBeCloseTo(((-1) * (1.0 - at)) + (6 * at), CLOSE_FACTOR);
+                                        });
+                        });
+
+                        it("works in case of floating values", function() {
+                            checkTweens([0, 1],
+                                        [ [ 'alpha', [ 0, 1 ], [.8, 1.2] ] ],
+                                        function(s, at) {
+                                            expect(s.alpha).toBeCloseTo((.8 * (1.0 - at)) + (1.2 * at), CLOSE_FACTOR);
+                                        });
+                        });
+
+                        it("works in case of band not equal to element's band", function() {
+                            checkTweens([.18, 1.76],
+                                        [ [ 'alpha', [.32, 1.64], [.5, .84] ] ],
+                                        function(s, at) {
+                                            // before the tween
+                                            if (at < (.18 + .32)) {
+                                                expect(s.alpha).toBe(.5);
+                                                return true;
+                                            }
+                                            // after the tween
+                                            if (at > (.18 + 1.64)) {
+                                                expect(s.alpha).toBe(.84);
+                                                return true;
+                                            }
+                                            // during the tween
+                                            var adt = (at - .32 - .18) / (1.64 - .32);
+                                            expect(s.alpha).toBeCloseTo((.5 * (1.0 - adt)) + (.84 * adt), CLOSE_FACTOR);
+                                        });
+                        });
 
                     });
 
@@ -1921,14 +1975,50 @@ describe("tweens", function() {
 
                     describe("default implementation", function() {
 
-                        describe("will override angle value of the state according to given rotation", function() {
+                        describe("will override alpha value of the state", function() {
 
                             describe("non-overlapping bands", function() {
 
                                 it("last-added modifier goes just after the first in timeline", function() {
+                                    checkTweens([.15, 2],
+                                                [ [ 'alpha', [ .3,   .9], [.3, 1.1] ],
+                                                  [ 'alpha', [1.1, 1.81], [.1,  .9] ] ],
+                                                function(s, at) {
+                                                    // before the tween
+                                                    if (at < (.15 + 1.1)) {
+                                                        expect(s.alpha).toBe(.1);
+                                                        return true;
+                                                    }
+                                                    // after the tween
+                                                    if (at > (.15 + 1.81)) {
+                                                        expect(s.alpha).toBe(.9);
+                                                        return true;
+                                                    }
+                                                    // during the tween
+                                                    var adt = (at - 1.1 - .15) / (1.81 - 1.1);
+                                                    expect(s.alpha).toBeCloseTo((.1 * (1.0 - adt)) + (.9 * adt), CLOSE_FACTOR);
+                                                });
                                 });
 
                                 it("last-added modifier goes just before the first in timeline", function() {
+                                    checkTweens([.15, 2],
+                                                [ [ 'alpha', [1.1, 1.81], [.1,  .9] ],
+                                                  [ 'alpha', [ .3,   .9], [.3, 1.1] ] ],
+                                                function(s, at) {
+                                                    // before the tween
+                                                    if (at < (.15 + .3)) {
+                                                        expect(s.alpha).toBe(.3);
+                                                        return true;
+                                                    }
+                                                    // after the tween
+                                                    if (at > (.15 + .9)) {
+                                                        expect(s.alpha).toBe(1.1);
+                                                        return true;
+                                                    }
+                                                    // during the tween
+                                                    var adt = (at - .3 - .15) / (.9 - .3);
+                                                    expect(s.alpha).toBeCloseTo((.3 * (1.0 - adt)) + (1.1 * adt), CLOSE_FACTOR);
+                                                });
                                 });
 
                             });
@@ -1936,161 +2026,160 @@ describe("tweens", function() {
                             describe("overlapping bands", function() {
 
                                 it("last-added modifier starting point goes after the first in timeline", function() {
+                                    checkTweens([.2, 1.8],
+                                                [ [ 'alpha', [.12,    .9 ], [.25,  5] ],
+                                                  [ 'alpha', [.54,  1.63 ], [  7, 20] ] ],
+                                                function(s, at) {
+                                                    // before the tween
+                                                    if (at < (.2 + .54)) {
+                                                        expect(s.alpha).toBe(7);
+                                                        return true;
+                                                    }
+                                                    // after the tween
+                                                    if (at > (.2 + 1.63)) {
+                                                        expect(s.alpha).toBe(20);
+                                                        return true;
+                                                    }
+                                                    // during the tween
+                                                    var adt = (at - .54 - .2) / (1.63 - .54);
+                                                    expect(s.alpha).toBeCloseTo((7 * (1.0 - adt)) + (20 * adt), CLOSE_FACTOR);
+                                                });
                                 });
 
                                 it("last-added modifier starting point goes before the first in timeline", function() {
+                                    checkTweens([.2, 1.8],
+                                                [ [ 'alpha', [.54,  1.63 ], [  7, 20] ],
+                                                  [ 'alpha', [.12,    .9 ], [.25,  5] ] ],
+                                                function(s, at) {
+                                                    // before the tween
+                                                    if (at < (.2 + .12)) {
+                                                        expect(s.alpha).toBe(.25);
+                                                        return true;
+                                                    }
+                                                    // after the tween
+                                                    if (at > (.2 + .9)) {
+                                                        expect(s.alpha).toBe(5);
+                                                        return true;
+                                                    }
+                                                    // during the tween
+                                                    var adt = (at - .12 - .2) / (.9 - .12);
+                                                    expect(s.alpha).toBeCloseTo((.25 * (1.0 - adt)) + (5 * adt), CLOSE_FACTOR);
+                                                });
+
                                 });
 
                             });
 
                             it("works with more than two tweens", function() {
+
+                                checkTweens([.1, 3],
+                                            [ [ 'alpha', [   0,   1 ], [ .2, .18 ] ],
+                                              [ 'alpha', [   1, 1.5 ], [ .5,  .8 ] ],
+                                              [ 'alpha', [ 1.3,   2 ], [ .6, .97 ] ] ],
+                                            function(s, at) {
+                                                // before the tween
+                                                if (at < (.1 + 1.3)) {
+                                                    expect(s.alpha).toBe(.6);
+                                                    return true;
+                                                }
+                                                // after the tween
+                                                if (at > (.1 + 2)) {
+                                                    expect(s.alpha).toBe(.97);
+                                                    return true;
+                                                }
+                                                // during the tween
+                                                var adt = (at - 1.3 - .1) / (2 - 1.3);
+                                                expect(s.alpha).toBeCloseTo((.6 * (1.0 - adt)) + (.97 * adt), CLOSE_FACTOR);
+                                            });
+
                             });
 
                         });
 
                         /* TODO: xdescribe("smart implementation", function{} {
 
+                            describe("should multiply alpha value of the state according to given opacity for several tweens in a band of element", function() {
+
+                                it("works with non-overlapping bands", function() {
+                                    checkTweens([.15, 2],
+                                                [ [ 'alpha', [ .3,   .9], [.3, 1.1] ],
+                                                  [ 'alpha', [1.1, 1.81], [.1,  .9] ] ],
+                                                function(s, at) {
+                                                    // before first tween
+                                                    if (at < (.15 + .3)) {
+                                                        expect(s.alpha).toBe(.3 * 0.1);
+                                                        return true;
+                                                    }
+                                                    // during first tween
+                                                    if (at < (.15 + .9)) {
+                                                        var adt = (at - .3 - .15) / (.9 - .3);
+                                                        expect(s.alpha).toBeCloseTo(0.1 * ((.3 * (1.0 - adt)) + (1.1 * adt)), CLOSE_FACTOR);
+                                                        return true;
+                                                    }
+                                                    // after first tween, before second
+                                                    if (at < (.15 + 1.1)) {
+                                                        expect(s.alpha).toBe(.1 * 1.1);
+                                                        return true;
+                                                    }
+                                                    // during second tween
+                                                    if (at < (.15 + 1.81)) {
+                                                        var adt = (at - 1.1 - .15) / (1.81 - 1.1);
+                                                        expect(s.alpha).toBeCloseTo(1.1 * ((.1 * (1.0 - adt)) + (0.9 * adt)), CLOSE_FACTOR);
+                                                        return true;
+                                                    }
+                                                    expect(s.alpha).toBe(1.1 * .9);
+                                                });
+                                });
+
+                                it("works with overlapping bands", function() {
+                                    checkTweens([.2, 1.8],
+                                                [ [ 'alpha', [.12,    .9 ], [.25,  5] ],
+                                                  [ 'alpha', [.54,  1.63 ], [  7, 20] ] ],
+                                                function(s, at) {
+                                                    // before first tween
+                                                    if (at < (.2 + .12)) {
+                                                        expect(s.alpha).toBe(.25 * 7);
+                                                        return true;
+                                                    }
+                                                    // during first tween, before overlap period
+                                                    if (at < (.2 + .54)) {
+                                                        var adt = (at - .12 - .2) / (.9 - .12);
+                                                        expect(s.alpha).toBeCloseTo(7 * ((.25 * (1.0 - adt)) + (5 * adt)), CLOSE_FACTOR);
+                                                        return true;
+                                                    }
+                                                    // during overlap period
+                                                    if (at < (.2 + .9)) {
+                                                        var adt1 = (at - .12 - .2) / (  .9 - .12),
+                                                            adt2 = (at - .54 - .2) / (1.63 - .54);
+                                                        expect(s.alpha).toBeCloseTo(((.25 * (1.0 - adt1)) + ( 5 * adt1)) *
+                                                                                    ((  7 * (1.0 - adt2)) + (20 * adt2)), CLOSE_FACTOR);
+                                                        return true;
+                                                    }
+                                                    // during second tween, after overlap period
+                                                    if (at < (.2 + 1.63)) {
+                                                        var adt = (at - .54 - .2) / (1.63 - .54);
+                                                        expect(s.alpha).toBeCloseTo(5 * ((7 * (1.0 - adt)) + (20 * adt)), CLOSE_FACTOR);
+                                                        return true;
+                                                    }
+                                                    // after second tween
+                                                    expect(s.alpha).toBe(5 * 20);
+                                                });
+                                });
+
+                                // it("works with more than two tweens", function() {
+                                //    checkTweens([0, 3],
+                                //                [ [ 'alpha', [   0,   1 ], [[5, 5], [10, 12]] ],
+                                //                  [ 'alpha', [   1, 1.5 ], [[7, 7], [9,  11]] ],
+                                //                  [ 'alpha', [ 1.5, 1.5 ], [[9, 8], [11, 22]] ] ],
+                                //                function(s, at) {
+                                //                });
+                                // });
+
+                            });
+
                         }); */
 
                     });
-
-                });
-
-                describe("should change alpha value of the state according to given opacity for a single tween", function() {
-
-                    it("works in case of simple values", function() {
-                        checkTweens([0, 1],
-                                    [ [ 'alpha', [ 0, 1 ], [3, 1] ] ],
-                                    function(s, at) {
-                                        expect(s.alpha).toBeCloseTo((3 * (1.0 - at)) + (1 * at), CLOSE_FACTOR);
-                                    });
-                    });
-
-                    it("works in case of zero", function() {
-                        checkTweens([0, 1],
-                                    [ [ 'alpha', [ 0, 1 ], [8, 0] ] ],
-                                    function(s, at) {
-                                        expect(s.alpha).toBeCloseTo((8 * (1.0 - at)) + (0 * at), CLOSE_FACTOR);
-                                    });
-
-                        // both zero, left zero?
-                    });
-
-                    it("works in case of mixed values (incl. negative)", function() {
-                        checkTweens([0, 1],
-                                    [ [ 'alpha', [ 0, 1 ], [-1, 6] ] ],
-                                    function(s, at) {
-                                        expect(s.alpha).toBeCloseTo(((-1) * (1.0 - at)) + (6 * at), CLOSE_FACTOR);
-                                    });
-                    });
-
-                    it("works in case of floating values", function() {
-                        checkTweens([0, 1],
-                                    [ [ 'alpha', [ 0, 1 ], [.8, 1.2] ] ],
-                                    function(s, at) {
-                                        expect(s.alpha).toBeCloseTo((.8 * (1.0 - at)) + (1.2 * at), CLOSE_FACTOR);
-                                    });
-                    });
-
-                    it("works in case of band not equal to element's band", function() {
-                        checkTweens([.18, 1.76],
-                                    [ [ 'alpha', [.32, 1.64], [.5, .84] ] ],
-                                    function(s, at) {
-                                        // before the tween
-                                        if (at < (.18 + .32)) {
-                                            expect(s.alpha).toBe(.5);
-                                            return true;
-                                        }
-                                        // after the tween
-                                        if (at > (.18 + 1.64)) {
-                                            expect(s.alpha).toBe(.84);
-                                            return true;
-                                        }
-                                        // during the tween
-                                        var adt = (at - .32 - .18) / (1.64 - .32);
-                                        expect(s.alpha).toBeCloseTo((.5 * (1.0 - adt)) + (.84 * adt), CLOSE_FACTOR);
-                                    });
-                    });
-
-                });
-
-                describe("should multiply alpha value of the state according to given opacity for several tweens in a band of element", function() {
-
-                    it("works with non-overlapping bands", function() {
-                        checkTweens([.15, 2],
-                                    [ [ 'alpha', [ .3,   .9], [.3, 1.1] ],
-                                      [ 'alpha', [1.1, 1.81], [.1,  .9] ] ],
-                                    function(s, at) {
-                                        // before first tween
-                                        if (at < (.15 + .3)) {
-                                            expect(s.alpha).toBe(.3 * 0.1);
-                                            return true;
-                                        }
-                                        // during first tween
-                                        if (at < (.15 + .9)) {
-                                            var adt = (at - .3 - .15) / (.9 - .3);
-                                            expect(s.alpha).toBeCloseTo(0.1 * ((.3 * (1.0 - adt)) + (1.1 * adt)), CLOSE_FACTOR);
-                                            return true;
-                                        }
-                                        // after first tween, before second
-                                        if (at < (.15 + 1.1)) {
-                                            expect(s.alpha).toBe(.1 * 1.1);
-                                            return true;
-                                        }
-                                        // during second tween
-                                        if (at < (.15 + 1.81)) {
-                                            var adt = (at - 1.1 - .15) / (1.81 - 1.1);
-                                            expect(s.alpha).toBeCloseTo(1.1 * ((.1 * (1.0 - adt)) + (0.9 * adt)), CLOSE_FACTOR);
-                                            return true;
-                                        }
-                                        expect(s.alpha).toBe(1.1 * .9);
-                                    });
-                    });
-
-                    it("works with overlapping bands", function() {
-                        checkTweens([.2, 1.8],
-                                    [ [ 'alpha', [.12,    .9 ], [.25,  5] ],
-                                      [ 'alpha', [.54,  1.63 ], [  7, 20] ] ],
-                                    function(s, at) {
-                                        // before first tween
-                                        if (at < (.2 + .12)) {
-                                            expect(s.alpha).toBe(.25 * 7);
-                                            return true;
-                                        }
-                                        // during first tween, before overlap period
-                                        if (at < (.2 + .54)) {
-                                            var adt = (at - .12 - .2) / (.9 - .12);
-                                            expect(s.alpha).toBeCloseTo(7 * ((.25 * (1.0 - adt)) + (5 * adt)), CLOSE_FACTOR);
-                                            return true;
-                                        }
-                                        // during overlap period
-                                        if (at < (.2 + .9)) {
-                                            var adt1 = (at - .12 - .2) / (  .9 - .12),
-                                                adt2 = (at - .54 - .2) / (1.63 - .54);
-                                            expect(s.alpha).toBeCloseTo(((.25 * (1.0 - adt1)) + ( 5 * adt1)) *
-                                                                        ((  7 * (1.0 - adt2)) + (20 * adt2)), CLOSE_FACTOR);
-                                            return true;
-                                        }
-                                        // during second tween, after overlap period
-                                        if (at < (.2 + 1.63)) {
-                                            var adt = (at - .54 - .2) / (1.63 - .54);
-                                            expect(s.alpha).toBeCloseTo(5 * ((7 * (1.0 - adt)) + (20 * adt)), CLOSE_FACTOR);
-                                            return true;
-                                        }
-                                        // after second tween
-                                        expect(s.alpha).toBe(5 * 20);
-                                    });
-                    });
-
-                    /* it("works with more than two tweens", function() {
-                        checkTweens([0, 3],
-                                    [ [ 'alpha', [   0,   1 ], [[5, 5], [10, 12]] ],
-                                      [ 'alpha', [   1, 1.5 ], [[7, 7], [9,  11]] ],
-                                      [ 'alpha', [ 1.5, 1.5 ], [[9, 8], [11, 22]] ] ],
-                                    function(s, at) {
-
-                                    });
-                    }); */
 
                 });
 


### PR DESCRIPTION
We've decided to postpone implementing smart-technique of overlapping tweens and just include overwriting into API.

So now, if there are two alpha tweens on the same element, even if their bands do not intersect, the last will overwrite changes of the previous ones. So if you want to make several changes to the same property of en element through its band, please use modifiers or create several clones (for now).
