### PR TITLE
added check for player-dev location

### DIFF
--- a/go
+++ b/go
@@ -131,7 +131,8 @@
 
             var CANVAS_ID = 'target',
                 PROTOCOL = ('https:' === document.location.protocol) ? 'https://' : 'http://',
-                URL_PREFIX = PROTOCOL + 'animatron-snapshots-dev.s3.amazonaws.com',
+                DOMAIN = document.location.contains('player-dev')? 'animatron-snapshots-dev.s3.amazonaws.com': 'snapshots.animatron.com';
+                URL_PREFIX = PROTOCOL + DOMAIN,
                 SNAPSHOT_ID = _version_specified ? _before_amp.substring(0, _snapshot_id_len)
                                                  : _before_amp,
                 VERSION_ID = _version_specified ? _before_amp.substring(_snapshot_id_len + 1)


### PR DESCRIPTION
ok the idea is to have the same 'go' script at both: player.animatron.com and player-dev.animatron.com
the script checks if it's loaded from player-dev and adjusts snapshot location accordingly
