### PR TITLE
Do not show invisible elements

### DIFF
--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -131,6 +131,7 @@ AnimatronImporter.prototype.findElement = function(id, source) {
 // collect required data from source layer
 AnimatronImporter.prototype._collectDynamicData = function(to, clip, in_band) {
     if (!to.name && clip.name) to.name = clip.name;
+    if (clip.visible === false) to.disabled = true; // to.visible = false;
     var x = to.xdata;
     x.lband = clip.band || [0, Infinity]; //FIMXE: remove, when it will be always set in project
     x.gband = in_band ? Bands.wrap(in_band, x.lband)

--- a/src/module/collisions.js
+++ b/src/module/collisions.js
@@ -644,14 +644,14 @@ Scene.prototype.handle__x = function(type, evt) {
             switch (type) {
                 case C.X_MCLICK: case C.X_MDCLICK: case C.X_MUP: case C.X_MDOWN: {
                     this.visitElems(function(elm) {
-                        if (elm.visible &&
+                        if (elm.shown &&
                             elm.contains(evt.pos)) elm.fire(type, evt);
                     });
                     return true;
                 }
                 case C.X_MMOVE: {
                     this.visitElems(function(elm) {
-                        if (elm.visible) {
+                        if (elm.shown) {
                             if (elm.contains(evt.pos)) {
                                 elm.fire(C.X_MMOVE, evt);
                                 if (elm.__wout) {

--- a/src/player.js
+++ b/src/player.js
@@ -1556,7 +1556,7 @@ Scene.prototype.render = function(ctx, time, zoom) {
 }
 Scene.prototype.handle__x = function(type, evt) {
     this.visitElems(function(elm) {
-        if (elm.visible) elm.fire(type, evt);
+        if (elm.shown) elm.fire(type, evt);
     });
     return true;
 }
@@ -1743,7 +1743,8 @@ function Element(draw, onframe) {
     this.children = [];
     this.parent = null;
     this.scene = null;
-    this.visible = false;
+    this.visible = true; // user flag, set by user
+    this.shown = false; // system flag, set by engine
     this.registered = false;
     this.disabled = false;
     this.rendering = false;
@@ -1817,7 +1818,8 @@ Element.prototype.render = function(ctx, gtime) {
     if (drawMe) {
         drawMe = this.fits(ltime)
                  && this.onframe(ltime)
-                 && this.prepare();
+                 && this.prepare()
+                 && this.visible;
     }
     if (drawMe) {
         // update gtime for children, if it was changed by ltime()
@@ -1875,9 +1877,9 @@ Element.prototype.render = function(ctx, gtime) {
                           dbl_scene_width, dbl_scene_height);
         }
     }
-    // immediately when drawn, element becomes visible,
+    // immediately when drawn, element becomes shown,
     // it is reasonable
-    this.visible = drawMe;
+    this.shown = drawMe;
     ctx.restore();
     this.__postRender();
     this.rendering = false;


### PR DESCRIPTION
Now `element.visible` flag is free for user to change and means that its logic (modifiers) will run, but the object will not be drawn.

For previous meaning ( system flag, showing _if this object was actually drawn_ ), there is `shown` flag exists now.

All elements that noted in projects, exported from Editor, as invisible, become disabled, though (because it actually means this, in Editor).
