### PR TITLE
Supporting non-strings in text elements

### DIFF
--- a/examples/text-test.html
+++ b/examples/text-test.html
@@ -1,0 +1,76 @@
+<!--
+ ~ Copyright (c) 2011-2013 by Animatron.
+ ~ All rights are reserved.
+ ~
+ ~ Animatron player is licensed under the MIT License, see LICENSE.
+ -->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The Animatron HTML5 Player Text Test</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="stylesheet" href="./demo.css" type="text/css" />
+
+    <script src="../src/vendor/matrix.js" type="text/javascript"></script>
+    <script src="../src/player.js" type="text/javascript"></script>
+    <script src="../src/builder.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      #__canvas1_info {
+        color: #f00;
+      }
+    </style>
+
+    <script type="text/javascript">
+      function start() {
+          var b = Builder._$, C = anm.C;
+
+          var scene1 = b().text([100, 100], "String Text");
+          var p1 = createPlayer('canvas1').load(scene1);
+
+          var scene2 = b().text([100, 100], 5);
+          var p2 = createPlayer('canvas2').load(scene2);
+
+          var scene3 = b().text([100, 100], ["test","with","multi-line"]);
+          var p3 = createPlayer('canvas3').load(scene3);        
+
+          var scene4 = b().text([100, 100], [1,2,3]);
+          var p4 = createPlayer('canvas4').load(scene4);
+      }
+    </script>
+  </head>
+
+  <body onload="start();">
+    <h1>The Animatron HTML5 Player Text Test</h1>
+    <hr/>
+
+    <pre><code>
+var scene1 = b().text([100, 100], "String Text");
+    </code></pre>
+    <canvas id="canvas1"></canvas>
+
+    <hr />
+    <pre><code>
+var scene2 = b().text([100, 100], 5);
+    </code></pre>
+    <canvas id="canvas2"></canvas>
+
+    <hr />
+    <pre><code>
+var scene3 = b().text([100, 100], ["test","with","multi-line"]);
+    </code></pre>
+    <canvas id="canvas3"></canvas>
+
+    <hr />
+    <pre><code>
+var scene4 = b().text([100, 100], [1,2,3]);
+    </code></pre>
+    <canvas id="canvas4"></canvas>
+
+
+    <div id="copyright"><span>© 2011-2013 by Animatron.</span></div>
+
+  </body>
+
+</html>

--- a/src/player.js
+++ b/src/player.js
@@ -4065,10 +4065,10 @@ Text.prototype.dimen = function() {
     if (!Text.__buff) throw new SysErr('no Text buffer, bounds call failed');
     var buff = Text.__buff;
     buff.style.font = this.font;
-    if (__str(this.lines)) {
-        buff.textContent = this.lines;
-    } else {
+    if (this.lines instanceof Array) {
         buff.textContent = this.lines.join('<br/>');
+    } else {
+        buff.textContent = this.lines.toString();
     }
     return (this._dimen = [ buff.offsetWidth,
                             buff.offsetHeight ]);
@@ -4108,14 +4108,14 @@ Text.prototype.cfill = function(color) {
 }
 Text.prototype.visitLines = function(func, data) {
     var lines = this.lines;
-    if (__str(lines)) {
-        func(lines, data);
-    } else {
+    if (lines instanceof Array) {
         var line;
         for (var i = 0, ilen = lines.length; i < ilen; i++) {
             line = lines[i];
             func(line, data);
         }
+    } else {
+        func(lines.toString(), data);
     }
 }
 Text.prototype.clone = function() {


### PR DESCRIPTION
Accidentally passing of a number to the text of an element produces a
very nondescript error, which made debugging an extremely lengthy
process.

Instead, I changed the code to accept any type of object (although
string is still preferred). It will automatically call the object's
`toString()` function when converting for the canvas.
