### PR TITLE
Return of a registration point for special purposes

### DIFF
--- a/examples/one-scene-local.html
+++ b/examples/one-scene-local.html
@@ -33,7 +33,10 @@
     <!-- <script src="./files/anm/js/tiger_project.js" type="text/javascript"></script> -->
     <!-- <script src="./files/anm/js/masks_by_sergo.js" type="text/javascript"></script> -->
     <!-- <script src="./files/anm/js/project_with_masks.3.noalpha.js" type="text/javascript"></script> -->
-    <script src="./files/anm/js/_1500stars_with_sound.js" type="text/javascript"></script>
+
+
+    <!-- <script src="./files/anm/js/_1500stars_with_sound.js" type="text/javascript"></script> -->
+    <script src="./files/anm/js/_static_pivot.js" type="text/javascript"></script>
 
     <script type="text/javascript">
       function start() {
@@ -42,8 +45,9 @@
           // canvas0
           var importer = new AnimatronImporter();
           var player = createPlayer('canvas');
-          //player.debug = true;
-          player.load(anm_scenes['1500stars_with_sound'], importer);
+          player.debug = true;
+          //player.load(anm_scenes['1500stars_with_sound'], importer);
+          player.load(anm_scenes.static_pivot, importer);
           player.play();
 
       }

--- a/src/builder.js
+++ b/src/builder.js
@@ -290,12 +290,12 @@ C.R_TL = [ 0.0, 0.0 ]; C.R_TC = [ 0.5, 0.0 ]; C.R_TR = [ 1.0, 0.0 ];
 C.R_ML = [ 0.0, 0.5 ]; C.R_MC = [ 0.5, 0.5 ]; C.R_MR = [ 1.0, 0.5 ];
 C.R_BL = [ 0.0, 1.0 ]; C.R_BC = [ 0.5, 1.0 ]; C.R_BR = [ 1.0, 1.0 ];
 // > builder.reg % (pt: Array[2,Float] | side: C.R_*) => Builder | Array[2,Float]
-/*Builder.prototype.reg = function(pt) {
+Builder.prototype.reg = function(pt) {
     var x = this.x;
     if (!pt) return x.reg;
     x.reg = pt || x.reg;
     return this;
-}*/
+}
 // > builder.pvt % (pt: Array[2,Float] | side: C.R_*) => Builder | Array[2,Float]
 Builder.prototype.pvt = function(pt) {
     var x = this.x;

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -71,7 +71,6 @@ AnimatronImporter.prototype.importElement = function(clip, source, in_band) {
     var target = new Element();
     // ( id, name?, reg?, band?, eid?, tweens?, layers?,
     //   visible?, outline?, locked?, outline-color?, dynamic?, opaque?, masked?, on-end? )
-    this._collectDynamicData(target, clip, in_band);
     if (clip.eid) {
         var inner = this.findElement(clip.eid, source);
         if (!inner.eid && !inner.layers) {
@@ -113,6 +112,7 @@ AnimatronImporter.prototype.importElement = function(clip, source, in_band) {
             }
         }
     }
+    this._collectDynamicData(target, clip, in_band);
     // FIXME: it is a not good way to do it, ask tool developers to return band for such elements
     if ((target.xdata.mode != C.R_ONCE) &&
         (target.children.length > 0) &&
@@ -136,7 +136,8 @@ AnimatronImporter.prototype._collectDynamicData = function(to, clip, in_band) {
     x.lband = Convert.band(clip.band);
     x.gband = in_band ? Bands.wrap(in_band, x.lband)
                       : x.lband;
-    x.reg = clip.reg || [0, 0];
+    x.pvt = [ 0, 0 ];
+    x.reg = clip.reg || [ 0, 0 ];
     // 'on-end' is the old-style end, 'end' is the current-style
     x.mode = clip['end'] ? Convert.mode(clip['end'].type)
                          : Convert.oldschool_mode(clip['on-end']);

--- a/src/player.js
+++ b/src/player.js
@@ -1746,7 +1746,7 @@ C.AC_NAMES[C.C_COPY] = 'copy';
 C.AC_NAMES[C.C_XOR] = 'xor';
 
 Element.DEFAULT_PVT = [ 0.5, 0.5 ];
-//Element.DEFAULT_REG = [ 0.5, 0.5 ];
+Element.DEFAULT_REG = [ 0.0, 0.0 ];
 
 Element.TYPE_MAX_BIT = 16;
 Element.PRRT_MAX_BIT = 8; // used to calculate modifiers/painters id's:
@@ -2483,7 +2483,7 @@ Element.prototype.deepClone = function() {
     if (src_x.sheet) trg_x.sheet = src_x.sheet.clone();
     trg_x.pos = [].concat(src_x.pos);
     trg_x.pvt = [].concat(src_x.pvt);
-    //trg_x.reg = [].concat(src_x.reg);
+    trg_x.reg = [].concat(src_x.reg);
     trg_x.lband = [].concat(src_x.lband);
     trg_x.gband = [].concat(src_x.gband);
     trg_x.keys = obj_clone(src_x.keys);
@@ -2854,8 +2854,8 @@ Element.createState = function(owner) {
 };
 // geometric data of the element
 Element.createXData = function(owner) {
-    return { 'pvt': Element.DEFAULT_PVT,      // pivot
-             /*'reg': Element.DEFAULT_REG,*/  // registration point
+    return { 'pvt': Element.DEFAULT_PVT,      // pivot (relative to dimensions)
+             'reg': Element.DEFAULT_REG,      // registration point (static values)
              'path': null,     // Path instanse, if it is a shape
              'text': null,     // Text data, if it is a text (`path` holds stroke and fill)
              'sheet': null,    // Sheet instance, if it is an image or a sprite sheet
@@ -2877,11 +2877,13 @@ Element.__addSysModifiers = function(elm) {
 }
 Element.__addSysPainters = function(elm) {
     elm.__paint({ type: Element.SYS_PNT }, Render.p_usePivot);
+    elm.__paint({ type: Element.SYS_PNT }, Render.p_useReg);
     elm.__paint({ type: Element.SYS_PNT }, Render.p_applyAComp);
     elm.__paint({ type: Element.SYS_PNT }, Render.p_drawXData);
 }
 Element.__addDebugRender = function(elm) {
     elm.__paint({ type: Element.DEBUG_PNT }, Render.p_drawPivot);
+    elm.__paint({ type: Element.DEBUG_PNT }, Render.p_drawReg);
     elm.__paint({ type: Element.DEBUG_PNT }, Render.p_drawName);
     elm.__paint({ type: Element.DEBUG_PNT,
                      priority: 1 },
@@ -3241,6 +3243,32 @@ Render.p_drawPivot = function(ctx, pvt) {
     ctx.restore();
 }
 
+Render.p_drawReg = function(ctx, reg) {
+    if (!(reg = reg || this.reg)) return;
+    ctx.save();
+    ctx.lineWidth = 1.0;
+    ctx.strokeStyle = '#00f';
+    ctx.fillStyle = 'rgba(0,0,255,.3)';
+    // WHY it is required??
+    ctx.translate(reg[0], reg[1]);
+    ctx.beginPath();
+    ctx.moveTo(-4, -4);
+    ctx.lineTo(4, -4);
+    ctx.lineTo(4, 4);
+    ctx.lineTo(-4, 4);
+    ctx.lineTo(-4, -4);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, -10);
+    ctx.lineTo(0, 0);
+    ctx.moveTo(3, 0);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+}
+// TODO: p_drawReg
+
 Render.p_drawXData = function(ctx) {
     var subj = this.path || this.text || this.sheet;
     if (!subj) return;
@@ -3258,6 +3286,12 @@ Render.p_drawName = function(ctx, name) {
 
 Render.p_applyAComp = function(ctx) {
     if (this.acomp) ctx.globalCompositeOperation = C.AC_NAMES[this.acomp];
+}
+
+Render.p_useReg = function(ctx) {
+    var reg = this.reg;
+    if ((reg[0] === 0) && (reg[1] === 0)) return;
+    ctx.translate(-reg[0], -reg[1]);
 }
 
 Render.p_usePivot = function(ctx) {

--- a/tests/spec/04.builder/21.statics-and-pivot.spec.js
+++ b/tests/spec/04.builder/21.statics-and-pivot.spec.js
@@ -332,5 +332,7 @@ describe("static modification", function() {
 
     // TODO: test normalized paths!
     // TODO: test constants!
+    // TODO: test xdata.reg (non-relative shift) among with xdata.pvt (relative shift)
+    // TODO: test coordinates in painters
 
 });


### PR DESCRIPTION
`b().reg([ 20, 55 ])` allows to change it.

How it's related to pivot point in player:
- **NB** it's common to name _pivot_ a point used for rotation tween and _registration point_ a point used for position and translation tweens in most of the tools, but it's **not** the case in the player, at least for now. See notes below on what exactly _pivot_ and _reg-point_ currently mean in player;
- pivot is specified relatively to the dimensions (even if they are updated dynamically) of an element, while registration point is specified in exact pixel values;
- pivot point and registration point are applied for all of the shapes one after another on every cycle of animation (pivot is first);
- default pivot is `[0.5, 0.5]` and default registration point is `[0, 0]`;
- it is recommended to use pivot in most cases and only when you are required to use exact pixels or do not know the dimensions of the object, then feel free to use registration point.
