### PR TITLE
Init file and support to store last imported project (for easy debug)

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -78,7 +78,8 @@ var SubDirs = {
 };
 
 var Files = {
-    Main: { PLAYER: 'player.js',
+    Main: { INIT: 'anm.js',
+            PLAYER: 'player.js',
             BUILDER: 'builder.js' },
     Ext: { VENDOR: [ 'matrix.js'/*, 'json2.js'*/ ],
            IMPORTERS: { _ALL_: [ 'animatron-importer.js',
@@ -97,28 +98,33 @@ var Bundles = [
     { name: 'Standard',
       file: 'standard',
       includes: _in_dir(Dirs.SRC + '/' + SubDirs.VENDOR, Files.Ext.VENDOR )
-        .concat(_in_dir(Dirs.SRC,                      [ Files.Main.PLAYER ])) },
+        .concat(_in_dir(Dirs.SRC,                      [ Files.Main.INIT,
+                                                         Files.Main.PLAYER ])) },
     { name: 'Animatron',
       file: 'animatron',
       includes: _in_dir(Dirs.SRC + '/' + SubDirs.VENDOR,      Files.Ext.VENDOR )
-        .concat(_in_dir(Dirs.SRC,                           [ Files.Main.PLAYER ]))
+        .concat(_in_dir(Dirs.SRC,                           [ Files.Main.INIT,
+                                                              Files.Main.PLAYER ]))
         .concat(_in_dir(Dirs.SRC + '/' + SubDirs.IMPORTERS, [ Files.Ext.IMPORTERS.ANM ])) // animatron-importer.js
         .concat(_in_dir(Dirs.SRC + '/' + SubDirs.MODULES,   [ Files.Ext.MODULES.AUDIO ])) }, // include audio module
     { name: 'Animatron-Publish',
       file: 'animatron-publish',
       includes: _in_dir(Dirs.SRC + '/' + SubDirs.VENDOR,      Files.Ext.VENDOR )
-        .concat(_in_dir(Dirs.SRC,                           [ Files.Main.PLAYER ]))
+        .concat(_in_dir(Dirs.SRC,                           [ Files.Main.INIT,
+                                                              Files.Main.PLAYER ]))
         .concat(_in_dir(Dirs.SRC + '/' + SubDirs.IMPORTERS, [ Files.Ext.IMPORTERS.ANM_PUBLISH ])) // animatron-publish-importer.js
         .concat(_in_dir(Dirs.SRC + '/' + SubDirs.MODULES,   [ Files.Ext.MODULES.AUDIO ])) }, // include audio module
     { name: 'Develop',
       file: 'develop',
       includes: _in_dir(Dirs.SRC + '/' + SubDirs.VENDOR, Files.Ext.VENDOR )
-        .concat(_in_dir(Dirs.SRC,                      [ Files.Main.PLAYER,
+        .concat(_in_dir(Dirs.SRC,                      [ Files.Main.INIT,
+                                                         Files.Main.PLAYER,
                                                          Files.Main.BUILDER ])) },
     { name: 'Hardcore',
       file: 'hardcore',
       includes: _in_dir(Dirs.SRC + '/' + SubDirs.VENDOR,  Files.Ext.VENDOR )
-        .concat(_in_dir(Dirs.SRC,                       [ Files.Main.PLAYER ]))
+        .concat(_in_dir(Dirs.SRC,                       [ Files.Main.INIT,
+                                                          Files.Main.PLAYER ]))
         .concat(_in_dir(Dirs.SRC + '/' + SubDirs.MODULES, Files.Ext.MODULES._ALL_ ))
         .concat(_in_dir(Dirs.SRC,                       [ Files.Main.BUILDER ])) }
 ];
@@ -700,6 +706,8 @@ task('_organize', function() {
 
     _print('Copy files to ' + Dirs.AS_IS + '..');
 
+    jake.cpR(_loc(Dirs.SRC   + '/' + Files.Main.INIT),
+             _loc(Dirs.AS_IS + '/' + Files.Main.INIT));
     jake.cpR(_loc(Dirs.SRC   + '/' + Files.Main.PLAYER),
              _loc(Dirs.AS_IS + '/' + Files.Main.PLAYER));
     jake.cpR(_loc(Dirs.SRC   + '/' + Files.Main.BUILDER),
@@ -740,6 +748,7 @@ task('_versionize', function() {
 
     _print('.. Main files');
 
+    versionize(_loc(Dirs.AS_IS + '/' + Files.Main.INIT));
     versionize(_loc(Dirs.AS_IS + '/' + Files.Main.PLAYER));
     versionize(_loc(Dirs.AS_IS + '/' + Files.Main.BUILDER));
 
@@ -820,6 +829,8 @@ task('_minify', { async: true }, function() {
 
     _print('.. Main files');
 
+    minifyWithCopyright(_loc(Dirs.AS_IS    + '/' + Files.Main.INIT),
+                        _loc(Dirs.MINIFIED + '/' + Files.Main.INIT));
     minifyWithCopyright(_loc(Dirs.AS_IS    + '/' + Files.Main.PLAYER),
                         _loc(Dirs.MINIFIED + '/' + Files.Main.PLAYER));
     minifyWithCopyright(_loc(Dirs.AS_IS    + '/' + Files.Main.BUILDER),

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Include one of them as a script to your page, and you're done!
 
 Also, all files are accessible separately, if you want:
 
-* For most of the cases you need just [`vendor/matrix.js`](http://player.animatron.com/latest/vendor/matrix.js) and [`player.js`](http://player.animatron.com/latest/player.js)
+* For most of the cases you need just [`vendor/matrix.js`](http://player.animatron.com/latest/vendor/matrix.js), [`anm.js`](http://player.animatron.com/latest/anm.js) and [`player.js`](http://player.animatron.com/latest/player.js)
 * If you plan to program animation in an easy way, include [`builder.js`](http://player.animatron.com/latest/builder.js) next to them.
 * If you want to import animations from Animatron tool, include [`import/animatron-importer.js`](http://player.animatron.com/latest/import/animatron-importer.js) then. The same for other importers.
-* If you want to use some hardcore module, i.e. collisions module, include [`module/collisions.js`](http://player.animatron.com/latest/module/collisions.js) __before__ the builder file (builder will add some features to itself depending on enabled modules), if it is used, or just in any place after player file, if it is not. The same for other modules.
+* If you want to use some hardcore module, i.e. collisions module, include [`module/collisions.js`](http://player.animatron.com/latest/module/collisions.js) __before__ the builder file (builder will add some features to itself depending on enabled modules, it is wrong, but will be fixed in later versions), if it is used, or just in any place after player file, if it is not. The same for other modules.
 
 URLs scheme for all of them is:
 
@@ -51,6 +51,7 @@ Clone `git@github.com:Animatron/player.git` to get your own copy.
 To use JS player in current state, download or copy from the cloned repository:
 
  * `src/vendor/matrix.js`
+ * `src/anm.js`
  * `src/player.js`
  * [Optional] `src/builder.js` (allows to build animations in a functional way)
  * [Optional] `src/module/collisions.js` (if you plan to test collisions / point-contains / intersections with your shapes)

--- a/doc/API.md
+++ b/doc/API.md
@@ -91,7 +91,7 @@ There is always a fresh copy of player's latest version lying in S3 cloud. To us
     1. __Develop__ ([`bundle/develop.js`](http://player.animatron.com/latest/bundle/develop.js)): vendor files + player + Builder that simplifies working with scenes in a way like JQuery simplifies working with DOM (described below in [Builder](#builder) section) — it will work ok for developing any general (in terms of code complexity) games or script-based animations.
     1. __Hardcore__ ([`bundle/hardcore.js`](http://player.animatron.com/latest/bundle/hardcore.js)): vendor files + player + Builder + additional modules (like collisions support) — intended to be used to write more complex games
 * If you want to ensure in which files you do actually add, follow these steps:
-    * For most of the cases you need just [`vendor/matrix.js`](http://player.animatron.com/latest/vendor/matrix.js) and [`player.js`](http://player.animatron.com/latest/player.js)
+    * For most of the cases you need just [`vendor/matrix.js`](http://player.animatron.com/latest/vendor/matrix.js), [`anm.js`](http://player.animatron.com/latest/anm.js) and [`player.js`](http://player.animatron.com/latest/player.js)
     * If you plan to program animation in an easy way, include [`builder.js`](http://player.animatron.com/latest/builder.js) next to them.
     * If you want to import animations from Animatron tool, include [`import/animatron-importer.js`](http://player.animatron.com/latest/import/animatron-importer.js) then. The same for other importers.
     * If you want to use some hardcore module, i.e. collisions module, include [`module/collisions.js`](http://player.animatron.com/latest/module/collisions.js) __before__ the builder file (builder will add some features to itself depending on enabled modules), if it is used, or just in any place after player file, if it is not. The same for other modules.
@@ -102,7 +102,7 @@ See examples from Local Copy-related chapter below on how to load scenes and pla
 
 ###### 2.2.a. ######
 
-To do so, either clone [the repository](https://github.com/Animatron/player) or just download the  [`anm.player.js`](https://raw.github.com/Animatron/player/master/src/player.js) and [`matrix.js`](https://raw.github.com/Animatron/player/master/src/vendor/matrix.js) <sub>(the last one is a super-tiny [proxy for transformation matrix](http://simonsarris.com/blog/471-a-transformation-class-for-canvas-to-keep-track-of-the-transformation-matrix), thanks to [Simon Sarris](http://simonsarris.com/))</sub> files in raw format. Now, include them in your HTML file:
+To do so, either clone [the repository](https://github.com/Animatron/player) or just download the [`anm.js`](https://raw.github.com/Animatron/player/master/src/anm.js), [`player.js`](https://raw.github.com/Animatron/player/master/src/player.js) and [`matrix.js`](https://raw.github.com/Animatron/player/master/src/vendor/matrix.js) <sub>(the last one is a super-tiny [proxy for transformation matrix](http://simonsarris.com/blog/471-a-transformation-class-for-canvas-to-keep-track-of-the-transformation-matrix), thanks to [Simon Sarris](http://simonsarris.com/))</sub> files in raw format. Now, include them in your HTML file:
 
     <!DOCTYPE html>
     <html>
@@ -110,6 +110,7 @@ To do so, either clone [the repository](https://github.com/Animatron/player) or 
       <head>
         <title>My Great Page</title>
      ➭  <script src="./src/vendor/matrix.js" type="text/javascript"></script>
+     ➭  <script src="./src/anm.js" type="text/javascript"></script>
      ➭  <script src="./src/player.js" type="text/javascript"></script>
      ➭  <!-- importer or scene files go here, if one required -->
      ➭  <script type="text/javascript">

--- a/examples/demo-local.html
+++ b/examples/demo-local.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="./demo.css" type="text/css" />
 
     <script src="../src/vendor/matrix.js" type="text/javascript"></script>
+    <script src="../src/anm.js" type="text/javascript"></script>
     <script src="../src/player.js" type="text/javascript"></script>
     <script src="../src/builder.js" type="text/javascript"></script>
     <script src="../src/import/animatron-importer.js" type="text/javascript"></script>

--- a/examples/one-scene-local.html
+++ b/examples/one-scene-local.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="./demo.css" type="text/css" />
 
     <script src="../src/vendor/matrix.js" type="text/javascript"></script>
+    <script src="../src/anm.js" type="text/javascript"></script>
     <script src="../src/player.js" type="text/javascript"></script>
     <script src="../src/builder.js" type="text/javascript"></script>
     <script src="../src/import/animatron-publish-importer.js" type="text/javascript"></script>
@@ -26,6 +27,9 @@
 
     <script type="text/javascript">
       function start() {
+          if (!window.__anm_conf) window.__anm_conf = {};
+          window.__anm_conf.logImport = true;
+
           var /*b = Builder._$, */C = anm.C;
 
           // canvas0

--- a/sandbox/sandbox.html
+++ b/sandbox/sandbox.html
@@ -18,6 +18,7 @@
 
     <!--
     <script src="http://player.animatron.com/latest/vendor/matrix.js" type="text/javascript"></script>
+    <script src="http://player.animatron.com/latest/anm.js" type="text/javascript"></script>
     <script src="http://player.animatron.com/latest/player.js" type="text/javascript"></script>
     <script src="http://player.animatron.com/latest/builder.js" type="text/javascript"></script>
     <script src="http://player.animatron.com/latest/module/collisions.js" type="text/javascript"></script>

--- a/src/anm.js
+++ b/src/anm.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-2013 by Animatron.
+ * All rights are reserved.
+ *
+ * Animatron player is licensed under the MIT License, see LICENSE.
+ *
+ * @VERSION
+ */
+
+// HERE SHOULD GO THE INITIALISATION OF ANM NAMESPACE WITH HELPERS AND GLOBALS
+
+(function() {
+
+    var PRIVATE_NAMESPACE = '__anm',
+        PRIVATE_CONF = '__anm_conf',
+        PUBLIC_NAMESPACE = 'anm';
+
+    var _GLOBAL_ = (typeof window !== 'undefined') ? window : GLOBAL;
+    var _window = (typeof window !== 'undefined') ? window : null,
+        _document = (typeof document !== 'undefined') ? document : null;
+
+    if (!_GLOBAL_) throw new Error('Failed to find global namespace');
+
+    // TODO: try the way of jasmine.getGlobal()
+
+    // window.__anm_conf || GLOBAL.__anm_conf
+    if (!_GLOBAL_[PRIVATE_CONF]) {
+        _GLOBAL_[PRIVATE_CONF] = {
+            logImport: false,
+            forceWindowScope: false
+        }
+    }
+    var _conf = _GLOBAL_[PRIVATE_CONF];
+
+    // TODO: Later, player should be placed in anm.Player and
+    //              builder should be placed in anm.Builder
+
+    var registerUsingAnm = (function(_namespace, _glob, _wnd, _conf) {
+        return function(name, produce) {
+            var isBrowser = _wnd || _conf.forceWindowScope,
+                isAmd = (typeof define === 'function' && define.amd),
+                isCommonJSModule = (typeof module != 'undefined'),
+                isCommonJSExports = (typeof exports === 'object');
+             // FIXME: Remove, replace with Engine injector
+            if (isBrowser) {
+                _glob[name] = produce(_glob[_namespace]);
+            } else if (isAmd) {
+                define([_namespace], produce);
+            } else if (isCommonJSModule) {
+                module.exports = produce(require(_namespace));
+            } else if (isCommonJSExports) {
+                produce(require(_namespace));
+            } else {
+                _glob[name] = produce(_glob[_namespace]);
+            }
+        }
+    })(PUBLIC_NAMESPACE, _GLOBAL_, _window, _conf);
+
+    var registerPlayer = (function(_namespace, _glob, _wnd, _doc, _conf) {
+        /*var _wnd_mock = {
+                    'setTimeout': setTimeout, 'clearTimeout': clearTimeout,
+                    'devicePixelRatio': 1,
+                    'addEventListener': function() {},
+                    'removeEventListener': function() {}
+                };*/
+
+        return function(produce) {
+            var isBrowser = _wnd || _conf.forceWindowScope,
+                isAmd = (typeof define === 'function' && define.amd),
+                isCommonJSModule = (typeof module != 'undefined'),
+                isCommonJSExports = (typeof exports === 'object');
+             // FIXME: Remove, replace with Engine injector
+            if (isBrowser) {
+                _wnd[_namespace] = _wnd[_namespace] || {};
+                produce(_glob, _wnd, _doc)(_wnd[_namespace]);
+            } else if (isAmd) {
+                define(produce(_glob, _wnd, _doc));
+            } else if (isCommonJSModule) {
+                module.exports = produce(_glob, _wnd, _doc)({});
+            } else if (isCommonJSExports) {
+                produce(_glob, _wnd, _doc)(exports);
+            } else {
+                _wnd[_namespace] = _wnd[_namespace] || {};
+                produce(_glob, _wnd, _doc)(_wnd[_namespace]);
+            }
+        }
+    })(PUBLIC_NAMESPACE, _GLOBAL_, _window, _document, _conf);
+
+    var foo = {}
+
+    // window.__anm || GLOBAL.__anm
+    _GLOBAL_[PRIVATE_NAMESPACE] = {
+        global: _GLOBAL_,
+        'undefined': foo.___undefined___,
+        conf: _conf,
+        namespace: PUBLIC_NAMESPACE,
+        registerPlayer: registerPlayer,
+        registerUsingAnm: registerUsingAnm
+    };
+
+    // FIXME: support Engines (DOM/NodeJS/...) from this point
+
+})();

--- a/src/builder.js
+++ b/src/builder.js
@@ -7,25 +7,9 @@
  * @VERSION
  */
 
-(function(root, name, produce) {
-    // Cross-platform injector
-    if (window && window.__anm_force_window_scope) { // FIXME: Remove
-        // Browser globals
-        root[name] = produce(root.anm);
-    } else if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['anm'], produce);
-    } else if (typeof module != 'undefined') {
-        // CommonJS / module
-        module.exports = produce(require('anm'));
-    } else if (typeof exports === 'object') {
-        // CommonJS / exports
-        produce(require('anm'));
-    } else {
-        // Browser globals
-        root[name] = produce(root.anm);
-    }
-})(this, 'Builder'/*, 'anm/builder'*/, function(anm) {
+(((typeof __anm !== 'undefined') && __anm.registerUsingAnm) || function() {
+    throw new Error('Player namespace is not initialized');
+})('Builder', function(anm) {
 
 var Path = anm.Path;
 var Element = anm.Element;

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -54,6 +54,9 @@ __MYSELF.prototype.configureAnim = function(prj) {
 __MYSELF.prototype.load = function(prj) {
     // ( framerate, dimension, background, duration,
     //   elements, scenes )
+    //if (window && window.console && window.__anm_conf && window.__anm_conf.logImport) console.log(prj);
+    if (console && (typeof __anm_conf !== 'undefined') && __anm_conf.logImport) console.log(prj);
+    if (typeof __anm !== 'undefined') __anm.lastImportedProject = prj;
     // FIXME: allow importing several scenes
     var scene =  this.importScene(prj.anim.scenes[0],
                                   prj.anim.elements);

--- a/src/import/animatron-publish-importer.js
+++ b/src/import/animatron-publish-importer.js
@@ -44,6 +44,9 @@ Import._type = function(src) {
  */
 // -> Scene
 Import.project = function(prj) {
+    //if (window && console && window.__anm_conf && window.__anm_conf.logImport) console.log(prj);
+    if (console && (typeof __anm_conf !== 'undefined') && __anm_conf.logImport) console.log(prj);
+    if (typeof __anm !== 'undefined') __anm.lastImportedProject = prj;
     var scenes_ids = prj.anim.scenes;
     if (!scenes_ids.length) throw new Error('No scenes found in given project');
     var root = new Scene(),

--- a/src/player.js
+++ b/src/player.js
@@ -52,34 +52,9 @@
 // Module Definition
 // -----------------------------------------------------------------------------
 
-(function(name, produce) {
-    // Cross-platform injector
-    var _wnd = (typeof window !== 'undefined') ? window : {
-        'setTimeout': setTimeout, 'clearTimeout': clearTimeout,
-        'devicePixelRatio': 1,
-        'addEventListener': function() {},
-        'removeEventListener': function() {}
-    };
-    var _doc = (typeof document !== 'undefined') ? document : null;
-    // TODO: var _factory = __anm_factory || { /*...*/ };
-    if (_wnd.__anm_force_window_scope) { // FIXME: Remove
-        _wnd[name] = _wnd[name] || {};
-        produce(_wnd, _doc)(_wnd[name]);
-    } else if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(produce(_wnd, _doc));
-    } else if (typeof module != 'undefined') {
-        // CommonJS / module
-        module.exports = produce(_wnd, _doc)({});
-    } else if (typeof exports === 'object') {
-        // CommonJS / exports
-        produce(_wnd, _doc)(exports);
-    } else {
-        // Browser globals
-        _wnd[name] = _wnd[name] || {};
-        produce(_wnd, _doc)(_wnd[name]);
-    }
-})('anm'/*, 'anm/player'*/, function($wnd, $doc) {
+(((typeof __anm !== 'undefined') && __anm.registerPlayer) || function() {
+    throw new Error('Player namespace is not initialized');
+})(function($glob, $wnd, $doc) {
 
 // Utils
 // -----------------------------------------------------------------------------
@@ -5066,7 +5041,7 @@ return function($trg) {
     }
     for (prop in __globals) {
         $trg._globals[prop] = __globals[prop];
-        $wnd[prop] = __globals[prop];
+        $glob[prop] = __globals[prop];
     }
 
     /*$trg.__js_pl_all = this;*/

--- a/tests/00.testutils.tests.html
+++ b/tests/00.testutils.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
              /* _files['tst.matchers'],
                 _files['tst.mocks'], */

--- a/tests/01.player.tests.html
+++ b/tests/01.player.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
                 _files['tst.matchers'],
                 _files['tst.mocks'],

--- a/tests/02.animations.tests.html
+++ b/tests/02.animations.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
              /* _files['tst.matchers'], */
                 _files['tst.mocks'],

--- a/tests/03.anm-import.tests.html
+++ b/tests/03.anm-import.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
                 _files['anm.import'],
              /* _files['tst.matchers'], */

--- a/tests/04.builder.tests.html
+++ b/tests/04.builder.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
                 _files['anm.builder'],
                 _files['tst.matchers'],

--- a/tests/05.collisions.tests.html
+++ b/tests/05.collisions.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
                 _files['anm.collisions'],
                 _files['tst.matchers'],

--- a/tests/06.bugs.tests.html
+++ b/tests/06.bugs.tests.html
@@ -21,12 +21,14 @@
   <script type="text/javascript" src="./spec/spec-list.js"></script>
 
   <script type="text/javascript">
-      window.__anm_force_window_scope = true;
+      if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
       queue(require)(
               [ _files['jasmine'],
                 _files['jasmine.html'],
                 _files['vnd.matrix'],
+                _files['anm.init'],
                 _files['anm.player'],
                 _files['anm.builder'],
                 _files['anm.collisions'],

--- a/tests/require-files.js
+++ b/tests/require-files.js
@@ -16,6 +16,7 @@ var _files = {
 
     'vnd.matrix': '../src/vendor/matrix.js',
 
+    'anm.init': '../src/anm.js',
     'anm.player': '../src/player.js',
     'anm.builder': '../src/builder.js',
     'anm.collisions': '../src/module/collisions.js',

--- a/tests/run-for-teamcity.html
+++ b/tests/run-for-teamcity.html
@@ -25,7 +25,8 @@
 
     <script type="text/javascript">
       function run_tests(on_finish, phantom) {
-        window.__anm_force_window_scope = true;
+        if (!window.__anm_conf) window.__anm_conf = {};
+      window.__anm_conf.forceWindowScope = true;
 
         queue(require)(
                 [ _files['jasmine'],
@@ -33,6 +34,7 @@
                   _files['jasmine.teamcity'],
                   _files['jasmine.phantom'],
                   _files['vnd.matrix'],
+                  _files['anm.init'],
                   _files['anm.player'],
                   _files['anm.builder'],
                   _files['anm.collisions'],

--- a/tests/run-for-terminal.html
+++ b/tests/run-for-terminal.html
@@ -38,7 +38,8 @@
        */
 
       function run_tests(on_finish, specs_to_run) {
-        window.__anm_force_window_scope = true;
+        if (!window.__anm_conf) window.__anm_conf = {};
+        window.__anm_conf.forceWindowScope = true;
 
         queue(require)(
                 [ _files['jasmine'],
@@ -46,6 +47,7 @@
                   _files['jasmine.tap'],
                   _files['jasmine.phantom'],
                   _files['vnd.matrix'],
+                  _files['anm.init'],
                   _files['anm.player'],
                   _files['anm.builder'],
                   _files['anm.collisions'],

--- a/tests/run-jasmine.phantom.js
+++ b/tests/run-jasmine.phantom.js
@@ -78,7 +78,8 @@ page.open(url, function(success) {
                 console.log("__error__");
             }
 
-            window.__anm_force_window_scope = true;
+            if (!window.__anm_conf) window.__anm_conf = {};
+            window.__anm_conf.forceWindowScope = true;
 
             run_tests(function(results) {
                 window.__jasmineResults = results;


### PR DESCRIPTION
Support for the init file (`anm.js`), which configures the namespace, manages the way of player initialization process, prepares and stores some private global configuration
This file is now also included into bundles.
Initialization blocks in sources are now look much more readable thanks to this file and now they contain just a few lines.
Now it is possible for developer to configure all player instances using some global variables, this way is now used to decide if log an imported project or not.
