### PR TITLE
The only saviour fix for current Rotate-to-Path problems!

### DIFF
--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -285,6 +285,7 @@ Import.branch = function(type, src, all, scene) {
                     });
                 }
             }
+            translates = [];
         }
 
         /** end-action **/

--- a/src/player.js
+++ b/src/player.js
@@ -3494,7 +3494,7 @@ var Tweens = {};
 Tweens[C.T_ROTATE] =
     function() {
       return function(t, dt, duration, data) {
-        this.angle = data[0] * (1 - t) + data[1] * t;
+        this.angle = data[0] * (1.0 - t) + data[1] * t;
         //state.angle = (Math.PI / 180) * 45;
       };
     };
@@ -3847,9 +3847,9 @@ Path.prototype.parse = function(str) {
 // > Path.hitAt % (t: [0..1]) => Array[Int, 2]
 Path.prototype.hitAt = function(t) {
     var plen = this.length(); // path length in pixels
-    if (t < 0 || t > plen) return null;
+    if (t < 0 || t > 1.0) return null;
 
-    var startp = this.start();
+    var startp = this.start(); // start point of segment
     if (t === 0) return {
           'seg': this.segs[0], 'start': startp, 'slen': 0.0, 'segt': 0.0
         };


### PR DESCRIPTION
Actually, the saviour is the line `translates = []` introduced here. Before, all translate tweens were accumulated in this variable due to function-scope nature of JavaScript implementation currently used. 

Glory to the Function! :clap:&nbsp;:railway_car:&nbsp;:raised_hands: 
