### PR TITLE
do not play audio if time is beyond its duration

### DIFF
--- a/src/module/audio.js
+++ b/src/module/audio.js
@@ -104,6 +104,11 @@ __anm_engine.define('anm/modules/audio', ['anm', 'anm/Player'], function(anm/*, 
     var current_time = this._audio_band_offset + ltime;
 
     if (m_ctx._audio_ctx) {
+      if (current_time > this.audio.duration) {
+        this._audio_is_playing = false;
+        return;
+      }
+
       this._source = m_ctx._audio_ctx.createBufferSource();
       this._source.buffer = this.audio;
       this._gain = m_ctx._audio_ctx.createGain();


### PR DESCRIPTION
Previously, `start()` was called even if the audio was already complete and negative duration was passed to WebAudio. This seems like undocumented behavior - Chrome, for example, played the sound from beginning in this case. This is now fixed.
