### PR TITLE
use loader on all fonts

### DIFF
--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -471,8 +471,8 @@ Animation.prototype.loadFonts = function(player) {
 
     for (var i = 0; i < fonts.length; i++) {
         var font = fonts[i];
-        if (!font.url || !font.face || detector.detect(font.face)) {
-            //no font name or url || font already available
+        if (!font.url || !font.face) {
+            //no font name or url
             continue;
         }
         if (https) {


### PR DESCRIPTION
previously, resource manager's `subscribe` was called on the font URLs, but if the font was already available, it was never loaded via `loadOrGet`, so `subscribe` would never fire a callback.
