### PR TITLE
Fix audio-master issues

### DIFF
--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -294,7 +294,7 @@ Element.prototype.initVisuals = function() {
     this.lastBoundsSavedAt = null; // time, when bounds were saved last time
     this.$my_bounds = null; // Element bounds on its own, cached
 
-    this.audio = null;
+    this.$audio = null;
 
     return this;
 };
@@ -2498,7 +2498,7 @@ Element.prototype._collectRemoteResources = function(anim, player) {
         resources.push(this.$image.src);
     }
     if (player.audioEnabled && this.is(C.ET_AUDIO)) {
-        resources.push(this.audio.url);
+        resources.push(this.$audio.url);
     }
 
     return resources;
@@ -2509,7 +2509,7 @@ Element.prototype._loadRemoteResources = function(anim, player) {
         this.$image.load(player.id);
     }
     if (this.is(C.ET_AUDIO) && player.audioEnabled) {
-        this.audio.load(player);
+        this.$audio.load(player);
     }
 };
 
@@ -2538,10 +2538,10 @@ Element.transferVisuals = function(src, trg) {
     trg.$path = src.$path ? src.$path.clone() : null;
     trg.$text = src.$text ? src.$text.clone() : null;
     trg.$image = src.$image ? src.$image.clone() : null;
+    trg.$audio = src.$audio ? src.$audio.clone() : null;
     trg.$mask = src.$mask ? src.$mask : null;
     trg.$mpath = src.$mpath ? src.$mpath.clone() : null;
     trg.composite_op = src.composite_op;
-    trg.audio = src.audio ? src.audio.clone() : null;
 };
 
 Element.transferTime = function(src, trg) {

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -180,9 +180,9 @@ Tween.addTween(C.T_SHADOW, function(data) {
 
 Tween.addTween(C.T_VOLUME, function(data){
     return function(t) {
-        if (!this.audio.loaded) return;
+        if (!this.$audio.loaded) return;
         var volume = data[0] * (1.0 - t) + data[1] * t;
-        this.audio.setVolume(volume);
+        this.$audio.setVolume(volume);
     };
 });
 

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -251,7 +251,7 @@ Audio.prototype.stop = function() {
 };
 /** @private @method stopIfNotMaster */
 Audio.prototype.stopIfNotMaster = function() {
-    if(!this.master) this.stop();
+    if (!this.master) this.stop();
 };
 /**
  * @method setVolume
@@ -295,7 +295,7 @@ Audio.prototype.mute = function() {
  * Unmute this audio
  */
 Audio.prototype.unmute = function() {
-    if(!this.muted) {
+    if (!this.muted) {
         return;
     }
     this.muted = false;
@@ -316,9 +316,15 @@ Audio.prototype.toggleMute = function() {
 /** @private @method connect */
 Audio.prototype.connect = function(element) {
     var me = this;
-    element.on(C.X_START, function() { me.play.apply(me, arguments); });
-    element.on(C.X_STOP, function() { me.stopIfNotMaster(); });
-    var stop = function() { me.stop(); };
+    element.on(C.X_START, function() {
+        me.play.apply(me, arguments);
+    });
+    element.on(C.X_STOP, function() {
+        me.stopIfNotMaster();
+    });
+    var stop = function() {
+        me.stop();
+    };
     element.on(C.S_STOP, stop);
     element.on(C.S_PAUSE, stop);
 };

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -1190,8 +1190,8 @@ Player.prototype.toggleMute = function() {
         return;
     }
     this.anim.traverse(function(el) {
-        if(el.audio) {
-            el.audio.toggleMute();
+        if(el.$audio) {
+            el.$audio.toggleMute();
         }
     });
 };

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -242,7 +242,8 @@ Controls.prototype.react = function() {
                 time = p.anim.duration;
             }
             if (s === C.PLAYING) {
-              p.pause().play(time);
+              p.pause()
+               .play(time);
             } else {
               p.play(time).pause();
             }

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -358,8 +358,8 @@ Import.branch = function(type, src, all, anim) {
 
         Import.callCustom(ltrg, lsrc, TYPE_LAYER);
 
-        // TODO temporary implementation
-        if (ltrg._audio_master) {
+        // TODO temporary implementation, use custom renderer for that!
+        if (ltrg.$audio && ltrg.$audio.master) {
             ltrg.lband = [ltrg.lband[0], Infinity];
             ltrg.gband = [ltrg.gband[0], Infinity];
             trg.remove(ltrg);
@@ -378,8 +378,8 @@ Import.leaf = function(type, src, parent/*, anim*/) {
     else if (type == TYPE_TEXT)  { trg.$text  = Import.text(src);  }
     else if (type == TYPE_AUDIO) {
         trg.type = C.ET_AUDIO;
-        trg.audio = Import.audio(src);
-        trg.audio.connect(trg);
+        trg.$audio = Import.audio(src);
+        trg.$audio.connect(trg);
     }
     else if (type == TYPE_VIDEO) {}
     else { trg.$path  = Import.path(src);  }


### PR DESCRIPTION
Due to removed `_audio_master ` flag, Master-Audio element was put inside Scene element, which was not correct and Scene band was less than Master-band. No flag directly in the Element anymore, moved it to `elm.$audio.master`. Also, renamed `elm.audio` to `elm.$audio` to match other types of elements.