### PR TITLE
change ordering of resource load

### DIFF
--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -377,6 +377,8 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
             state.happens = C.RES_LOADING;
             player.fire(C.S_CHANGE_STATE, C.RES_LOADING);
             player.fire(C.S_RES_LOAD, remotes);
+            // actually start loading remote resources
+            anim._loadRemoteResources(player);
             // subscribe to wait until remote resources will be ready or failed
             resourceManager.subscribe(player.id, remotes, [ player.__defAsyncSafe(
                 function(res_results, err_count) {
@@ -400,8 +402,6 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                     }
                 }
             ) ]);
-            // actually start loading remote resources
-            anim._loadRemoteResources(player);
         }
 
     };

--- a/src/anm/resource_manager.js
+++ b/src/anm/resource_manager.js
@@ -83,6 +83,7 @@ ResourceManager.prototype.subscribe = function(subject_id, urls, callbacks) {
     }
     this._subscriptions[subject_id] = [ filteredUrls,
                                         is.arr(callbacks) ? callbacks : [ callbacks ] ];
+    this.check(); // all the urls might be already available
 };
 
 ResourceManager.prototype.loadOrGet = function(subject_id, url, loader, onComplete, onError) {


### PR DESCRIPTION
When loading a movie for a second time, the resource manager notified the player that the resources are ready before the actual `loadOrGet`s happened. This led to the player starting playback when some of the elements (namely audio) were not yet ready. This is now fixed.