### PR TITLE
floor the drawImage w/h when drawing masks

### DIFF
--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -918,7 +918,7 @@ Element.prototype.render = function(ctx, gtime, dt) {
                 bctx.drawImage(mcvs, 0, 0);
 
                 ctx.drawImage(bcvs,
-                    0, 0, width * scale, height * scale,
+                    0, 0, Math.floor(width * scale), Math.floor(height * scale),
                     x, y, width, height);
 
                 mctx.restore();


### PR DESCRIPTION
This fixes a nasty bug under IE11 when the mask were not rendered if `window.devicePixelRatio` was a non-whole number (e.g. 1.25 - default setting on many Windows 8 laptops).