### PR TITLE
Show Resource Loading Completeness

### DIFF
--- a/src/anm/graphics/sheet.js
+++ b/src/anm/graphics/sheet.js
@@ -61,7 +61,7 @@ Sheet.prototype.load = function(player_id, callback, errback) {
         return;
     }
     resMan.loadOrGet(player_id, me.src,
-        function(notify_success, notify_error) { // loader
+        function(notify_success, notify_error, notify_progress) { // loader
             var src = me.src;
             if (https) {
                 src = src.replace('http:', 'https:');

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -141,6 +141,8 @@ Audio.prototype.load = function(player) {
                     el.removeEventListener("progress", progressListener, false);
                     el.removeEventListener("canplay", canPlayListener, false);
                     notify_success(el);
+                    console.log(me.url, 'notify finish');
+                    notify_progress(1);
                     return;
                   }
 
@@ -154,9 +156,25 @@ Audio.prototype.load = function(player) {
                 // will skip preloading since it seems like it will not work properly anyway:
                 // it's a workaround for Android-based browsers which
                 // will not allow prebuffering until user will explicitly allow it (by touching something)
+                console.log(me.url, 'notify finish');
                 notify_success(el);
               }
             };
+
+            var loadingListener = function(e) {
+                var ranges = [];
+                for (var i = 0; i < el.buffered.length; i++) {
+                    ranges.push([ el.buffered.start(i),
+                                  el.buffered.end(i) ]);
+                }
+
+                for (var i = 0, progress = 0; i < el.buffered.length; i ++) {
+                    progress += (100 / el.duration) * (ranges[i][1] - ranges[i][0]);
+                }
+
+                console.log(me.url, 'notify progress', progress);
+                notify_progress(progress);
+            }
 
             var canPlayListener = function(e) {
               me.canPlay = true;
@@ -164,6 +182,8 @@ Audio.prototype.load = function(player) {
             };
 
             el.addEventListener("progress", progressListener, false);
+            el.addEventListener("progress", loadingListener, false);
+            el.addEventListener("loadedmetadata", loadingListener, false);
             el.addEventListener("canplay", canPlayListener, false);
             el.addEventListener("error", audioErrProxy(url, notify_error), false);
 

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -2,7 +2,8 @@ var C = require('../constants.js'),
     engine = require('engine'),
     ResMan = require('../resource_manager.js'),
     conf = require('../conf.js'),
-    log = require('../log.js');
+    log = require('../log.js'),
+    utils = require('../utils.js');
 
 // workaround, see http://stackoverflow.com/questions/10365335/decodeaudiodata-returning-a-null-error
 function syncStream(node){
@@ -139,9 +140,10 @@ Audio.prototype.load = function(player) {
               if (buffered.length == 1) {
                   if (el.readyState === 4) {
                     el.removeEventListener("progress", progressListener, false);
+                    el.removeEventListener("progress", loadingListener, false);
+                    el.removeEventListener("loadedmetadata", loadingListener, false);
                     el.removeEventListener("canplay", canPlayListener, false);
                     notify_success(el);
-                    console.log(me.url, 'notify finish');
                     notify_progress(1);
                     return;
                   }
@@ -156,8 +158,8 @@ Audio.prototype.load = function(player) {
                 // will skip preloading since it seems like it will not work properly anyway:
                 // it's a workaround for Android-based browsers which
                 // will not allow prebuffering until user will explicitly allow it (by touching something)
-                console.log(me.url, 'notify finish');
                 notify_success(el);
+                notify_progress(1);
               }
             };
 
@@ -172,7 +174,6 @@ Audio.prototype.load = function(player) {
                     progress += (1 / el.duration) * (ranges[i][1] - ranges[i][0]);
                 }
 
-                console.log(me.url, 'notify progress', progress);
                 notify_progress(progress);
             }
 

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -84,7 +84,7 @@ function Audio(url) {
 Audio.prototype.load = function(player) {
     var me = this;
     ResMan.loadOrGet(player.id, me.url,
-      function(notify_success, notify_error) { // loader
+      function(notify_success, notify_error, notify_progress) { // loader
           var url = me.url;
           if (engine.isHttps) {
               url = url.replace('http:', 'https:');

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -169,7 +169,7 @@ Audio.prototype.load = function(player) {
                 }
 
                 for (var i = 0, progress = 0; i < el.buffered.length; i ++) {
-                    progress += (100 / el.duration) * (ranges[i][1] - ranges[i][0]);
+                    progress += (1 / el.duration) * (ranges[i][1] - ranges[i][0]);
                 }
 
                 console.log(me.url, 'notify progress', progress);

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -399,8 +399,8 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                         }
                     }
                 }
-            ) ], function(url, progress, errors) {
-                console.log(url, 'progress', progress, 'errors', errors);
+            ) ], function(url, factor, progress, errors) {
+                console.log(url, 'factor', factor, 'progress', progress, 'errors', errors);
             });
             // actually start loading remote resources
             anim._loadRemoteResources(player);

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -399,9 +399,10 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                         }
                     }
                 }
-            ) ], function(url, factor, progress, errors) {
-                console.log(url, 'factor', factor, 'progress', progress, 'errors', errors);
-            });
+            ) ], (player.controlsEnabled && player.controls) ? function(url, factor, progress, errors) {
+                player.controls.loadingProgress = progress;
+                player.controls.loadingErrors = errors;
+            } : null);
             // actually start loading remote resources
             anim._loadRemoteResources(player);
         }

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -377,8 +377,6 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
             state.happens = C.RES_LOADING;
             player.fire(C.S_CHANGE_STATE, C.RES_LOADING);
             player.fire(C.S_RES_LOAD, remotes);
-            // actually start loading remote resources
-            anim._loadRemoteResources(player);
             // subscribe to wait until remote resources will be ready or failed
             resourceManager.subscribe(player.id, remotes, [ player.__defAsyncSafe(
                 function(res_results, err_count) {
@@ -401,7 +399,11 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                         }
                     }
                 }
-            ) ]);
+            ) ], function(url, progress, errors) {
+                console.log(url, 'progress', progress, 'errors', errors);
+            });
+            // actually start loading remote resources
+            anim._loadRemoteResources(player);
         }
 
     };

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -196,7 +196,8 @@ Controls.prototype.render = function(gtime) {
         state.changed = false;
     } else if ((s === C.LOADING) || (s === C.RES_LOADING)) {
         drawBack(ctx, theme, w, h);
-        drawLoadingProgress(ctx, w, h, ((gtime / 100  % 60) / 60));
+        drawLoadingProgress(ctx, w, h, ((gtime / 100  % 60) / 60),
+                            this.loadingProgress, this.loadingErrors);
     } else if (s === C.ERROR) {
         drawBack(ctx, theme, w, h);
         drawError(ctx, theme, w, h, player.__lastError, this.focused);
@@ -534,7 +535,7 @@ var drawVolumeBtn = function(ctx, w, h, muted) {
 };
 
 //draw the loader
-var drawLoadingProgress = function(ctx, w, h, hilite_pos) {
+var drawLoadingProgress = function(ctx, w, h, hilite_pos, factor, errorFactor) {
     var cx = w / 2,
         cy = h / 2,
         segment = Math.ceil(90 * hilite_pos),
@@ -554,6 +555,28 @@ var drawLoadingProgress = function(ctx, w, h, hilite_pos) {
     ctx.arc(0,0,36,segmentPos, segmentPos + segmentAngle);
     ctx.stroke();
     ctx.closePath();
+
+    // draw loading progress at the bottom
+    if (factor || errorFactor) {
+        ctx.translate(-cx, cy - 2); // bottom right corner - 2px
+        ctx.strokeStyle = theme.loading.factorBackColor;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(w, 0);
+        ctx.stroke();
+        ctx.strokeStyle = theme.loading.factorDoneColor;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(w * factor, 0);
+        ctx.stroke();
+        if (errorFactor) {
+            ctx.strokeStyle = theme.loading.factorErrorColor;
+            ctx.moveTo(w * factor, 0);
+            ctx.lineTo(w * errorFactor, 0);
+            ctx.stroke();
+        }
+    }
 };
 
 var drawNoAnimation = function(ctx, theme, w, h, focused) {

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -558,9 +558,9 @@ var drawLoadingProgress = function(ctx, w, h, hilite_pos, factor, errorFactor) {
 
     // draw loading progress at the bottom
     if (factor || errorFactor) {
-        ctx.translate(-cx, cy - 2); // bottom right corner - 2px
+        ctx.translate(-cx, cy - theme.loading.factorLineWidth); // bottom right corner - 2px
         ctx.strokeStyle = theme.loading.factorBackColor;
-        ctx.lineWidth = 2;
+        ctx.lineWidth = theme.loading.factorLineWidth;
         ctx.beginPath();
         ctx.moveTo(0, 0);
         ctx.lineTo(w, 0);

--- a/src/anm/ui/controls_theme.json
+++ b/src/anm/ui/controls_theme.json
@@ -27,9 +27,10 @@
     "loading": {
       "activeColor": "white",
       "inactiveColor": "rgba(255,255,255,0.5)",
-      "factorBackColor": "rgba(100,100,100,0.5)",
-      "factorDoneColor": "rgba(255,255,255,0.5)",
-      "factorErrorColor": "rgba(255,0,0,0.5)"
+      "factorBackColor": "rgba(100,100,100,1)",
+      "factorDoneColor": "rgba(255,255,255,1)",
+      "factorErrorColor": "rgba(255,0,0,0.8)",
+      "factorLineWidth": 4
     },
     "fadeTimes": {
         "fadein": 300,

--- a/src/anm/ui/controls_theme.json
+++ b/src/anm/ui/controls_theme.json
@@ -26,7 +26,10 @@
     },
     "loading": {
       "activeColor": "white",
-        "inactiveColor": "rgba(255,255,255,0.5)"
+      "inactiveColor": "rgba(255,255,255,0.5)",
+      "factorBackColor": "rgba(100,100,100,0.5)",
+      "factorDoneColor": "rgba(255,255,255,0.5)",
+      "factorErrorColor": "rgba(255,0,0,0.5)"
     },
     "fadeTimes": {
         "fadein": 300,


### PR DESCRIPTION
Draws a tiny 2px-line at the bottom of controls to show the completeness of resources loading process. 

For audio, it has the ability to monitor chunks, [this demo](http://jspro.brothercake.com/media-events/progress.html) and [this article](http://www.sitepoint.com/essential-audio-and-video-events-for-html5/) were used to find out how to do it. For images, it just reports when they are done loading. The total number of URLs requested is used as `1.0`, each file is then `1 / <number-of-urls>` part in the progress line. For audio files, this value is then divided into sub-parts.

![Demo](https://dl.dropboxusercontent.com/s/qre8q43wqd76bjt/2015-02-10%20at%2022.53%202x.png)

(sorry, I was able to catch only the last moments of loading :) ).

Needs testing.

Also I ask to merge this just after the request, since it contains ResourceManager changes which should be considered by Yuri in his proposals and/or changes :). Code review fixes could be done with the next pull requests.

@alexeypegov @mcm69 please review.