### PR TITLE
Avoid try catch

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 by Animatron.
+ * Copyright (c) 2011-2015 by Animatron.
  * All rights are reserved.
  *
  * Animatron player is licensed under the MIT License, see LICENSE.
@@ -40,7 +40,7 @@ var VERSION_FILE = 'VERSION',
        return JSON.parse(jake.cat(_loc(file)).trim());
     })(PACKAGE_FILE);
 
-var COPYRIGHT_YEAR = 2014;
+var COPYRIGHT_YEAR = 2015;
 var COPYRIGHT_COMMENT =
 [ '/*',
   ' * Copyright (c) 2011-' + COPYRIGHT_YEAR + ' by Animatron.',

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -154,8 +154,16 @@ Animation.prototype.remove = function(elm) {
  * @param {Object} [data]
  */
 Animation.prototype.traverse = function(visitor, data) {
-    for (var elmId in this.hash) {
-        visitor(this.hash[elmId], data);
+    if (Object.keys) {
+        var hash = this.hash;
+        var ids = Object.keys(hash);
+        for (var i = 0; i < ids.length; i++) {
+            visitor(hash[ids[i]], data);
+        }
+    } else {
+        for (var elmId in this.hash) {
+            visitor(this.hash[elmId], data);
+        }
     }
     return this;
 };

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -80,7 +80,6 @@ Animation.DEFAULT_DURATION = 10;
 provideEvents(Animation, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                            C.X_MMOVE, C.X_MOVER, C.X_MOUT,
                            C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                           C.X_DRAW,
                            // player events
                            C.S_CHANGE_STATE,
                            C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
@@ -224,7 +223,6 @@ Animation.prototype.render = function(ctx, time, dt) {
         child.render(ctx, time, dt);
     });
     ctx.restore();
-    this.fire(C.X_DRAW,ctx);
 };
 
 Animation.prototype.handle__x = function(type, evt) {

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -75,15 +75,9 @@ function Animation() {
 
 Animation.DEFAULT_DURATION = 10;
 
-// mouse/keyboard events are assigned in L.loadAnimation
-/* TODO: move them into animation */
 provideEvents(Animation, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                            C.X_MMOVE, C.X_MOVER, C.X_MOUT,
-                           C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                           // player events
-                           C.S_CHANGE_STATE,
-                           C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
-                           C.S_IMPORT, C.S_LOAD, C.S_RES_LOAD, C.S_ERROR ]);
+                           C.X_KPRESS, C.X_KUP, C.X_KDOWN, C.X_ERROR ]);
 /**
  * @method add
  * @chainable
@@ -225,13 +219,6 @@ Animation.prototype.render = function(ctx, time, dt) {
     ctx.restore();
 };
 
-Animation.prototype.handle__x = function(type, evt) {
-    this.traverse(function(elm) {
-        elm.fire(type, evt);
-    });
-    return true;
-};
-
 // TODO: test
 /**
  * @method getFittingDuration
@@ -349,7 +336,12 @@ Animation.prototype._register = function(elm) {
     elm.registered = true;
     elm.anim = this;
     this.hash[elm.id] = elm;
+
     var me = this;
+
+    if (this.__err_handlers) this.__err_handlers = {};
+    this.__err_handlers[elm.id] = elm.on(C.X_ERROR, function(err) { me.fire(C.X_ERROR, err); });
+
     elm.each(function(child) {
         me._register(child);
     });
@@ -372,6 +364,7 @@ Animation.prototype._unregister = function(elm, save_in_tree) { // save_in_tree 
       }
     }
     delete this.hash[elm.id];
+    elm.unbind(C.X_ERROR, this.__err_handlers[elm.id]);
     elm.registered = false;
     elm.anim = null;
     //elm.parent = null;

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -319,7 +319,7 @@ Animation.prototype.unsubscribeEvents = function(canvas) {
  * @param {anm.Element} element
  */
 Animation.prototype.addToTree = function(elm) {
-    if (!elm.children) errors.animation(ErrLoc.A.OBJECT_IS_NOT_ELEMENT, this);
+    if (!elm.children) throw errors.animation(ErrLoc.A.OBJECT_IS_NOT_ELEMENT, this);
     this._register(elm);
     /*if (elm.children) this._addElems(elm.children);*/
     this.tree.push(elm);
@@ -332,7 +332,7 @@ Animation.prototype.addToTree = function(elm) {
     }
 }*/
 Animation.prototype._register = function(elm) {
-    if (this.hash[elm.id]) errors.animation(ErrLoc.A.ELEMENT_IS_REGISTERED, this);
+    if (this.hash[elm.id]) throw errors.animation(ErrLoc.A.ELEMENT_IS_REGISTERED, this);
     elm.registered = true;
     elm.anim = this;
     this.hash[elm.id] = elm;
@@ -352,7 +352,7 @@ Animation.prototype._unregister_no_rm = function(elm) {
 };
 
 Animation.prototype._unregister = function(elm, save_in_tree) { // save_in_tree is optional and false by default
-    if (!elm.registered) errors.animation(ErrLoc.A.ELEMENT_IS_NOT_REGISTERED, this);
+    if (!elm.registered) throw errors.animation(ErrLoc.A.ELEMENT_IS_NOT_REGISTERED, this);
     var me = this;
     elm.each(function(child) {
         me._unregister(child);

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -204,19 +204,18 @@ Animation.prototype.iter = function(func, rfunc) {
 Animation.prototype.render = function(ctx, time, dt) {
     ctx.save();
     var zoom = this.zoom;
-    try {
-        if (zoom != 1) {
-            ctx.scale(zoom, zoom);
-        }
-        if (this.bgfill) {
-            if (!(this.bgfill instanceof Brush)) this.bgfill = Brush.fill(this.bgfill);
-            this.bgfill.apply(ctx);
-            ctx.fillRect(0, 0, this.width, this.height);
-        }
-        this.each(function(child) {
-            child.render(ctx, time, dt);
-        });
-    } finally { ctx.restore(); }
+    if (zoom != 1) {
+        ctx.scale(zoom, zoom);
+    }
+    if (this.bgfill) {
+        if (!(this.bgfill instanceof Brush)) this.bgfill = Brush.fill(this.bgfill);
+        this.bgfill.apply(ctx);
+        ctx.fillRect(0, 0, this.width, this.height);
+    }
+    this.each(function(child) {
+        child.render(ctx, time, dt);
+    });
+    ctx.restore();
     this.fire(C.X_DRAW,ctx);
 };
 

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -339,8 +339,8 @@ Animation.prototype._register = function(elm) {
 
     var me = this;
 
-    if (this.__err_handlers) this.__err_handlers = {};
-    this.__err_handlers[elm.id] = elm.on(C.X_ERROR, function(err) { me.fire(C.X_ERROR, err); });
+    //if (!this.__err_handlers) this.__err_handlers = {};
+    //this.__err_handlers[elm.id] = elm.on(C.X_ERROR, function(err) { me.fire(C.X_ERROR, err); });
 
     elm.each(function(child) {
         me._register(child);

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -1,16 +1,19 @@
-var C = require('../constants.js'),
-    engine = require('engine'),
-    Element = require('./element.js'),
-    Clip = Element,
-    Brush = require('../graphics/brush.js'),
-    provideEvents = require('../events.js').provideEvents,
-    AnimationError = require('../errors.js').AnimationError,
-    Errors = require('../loc.js').Errors,
-    ResMan = require('../resource_manager.js'),
-    FontDetector = require('../../vendor/font_detector.js'),
-    utils = require('../utils.js'),
+var utils = require('../utils.js'),
     is = utils.is,
-    iter = utils.iter;
+    iter = utils.iter,
+    C = require('../constants.js');
+
+var engine = require('engine'),
+    ResMan = require('../resource_manager.js'),
+    FontDetector = require('../../vendor/font_detector.js');
+
+var Element = require('./element.js'),
+    Clip = Element,
+    Brush = require('../graphics/brush.js');
+
+var provideEvents = require('../events.js').provideEvents,
+    errors = require('../errors.js'),
+    ErrLoc = require('../loc.js').Errors;
 
 
 /* X_ERROR, X_FOCUS, X_RESIZE, X_SELECT, touch events */
@@ -130,8 +133,7 @@ Animation.prototype.add = function(arg1, arg2, arg3) {
  * @param {anm.Element} element
  */
 Animation.prototype.remove = function(elm) {
-    // error will be thrown in _unregister method
-    //if (!this.hash[elm.id]) throw new AnimErr(Errors.A.ELEMENT_IS_NOT_REGISTERED);
+    // error will be thrown in _unregister method if element is not registered
     if (elm.parent) {
         // it will unregister element inside
         elm.parent.remove(elm);
@@ -325,9 +327,7 @@ Animation.prototype.unsubscribeEvents = function(canvas) {
  * @param {anm.Element} element
  */
 Animation.prototype.addToTree = function(elm) {
-    if (!elm.children) {
-        throw new AnimationError('It appears that it is not a clip object or element that you pass');
-    }
+    if (!elm.children) errors.animation(ErrLoc.A.OBJECT_IS_NOT_ELEMENT);
     this._register(elm);
     /*if (elm.children) this._addElems(elm.children);*/
     this.tree.push(elm);
@@ -340,7 +340,7 @@ Animation.prototype.addToTree = function(elm) {
     }
 }*/
 Animation.prototype._register = function(elm) {
-    if (this.hash[elm.id]) throw new AnimationError(Errors.A.ELEMENT_IS_REGISTERED);
+    if (this.hash[elm.id]) errors.animation(ErrLoc.A.ELEMENT_IS_REGISTERED);
     elm.registered = true;
     elm.anim = this;
     this.hash[elm.id] = elm;
@@ -355,7 +355,7 @@ Animation.prototype._unregister_no_rm = function(elm) {
 };
 
 Animation.prototype._unregister = function(elm, save_in_tree) { // save_in_tree is optional and false by default
-    if (!elm.registered) throw new AnimationError(Errors.A.ELEMENT_IS_NOT_REGISTERED);
+    if (!elm.registered) errors.animation(ErrLoc.A.ELEMENT_IS_NOT_REGISTERED);
     var me = this;
     elm.each(function(child) {
         me._unregister(child);

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -319,7 +319,7 @@ Animation.prototype.unsubscribeEvents = function(canvas) {
  * @param {anm.Element} element
  */
 Animation.prototype.addToTree = function(elm) {
-    if (!elm.children) errors.animation(ErrLoc.A.OBJECT_IS_NOT_ELEMENT);
+    if (!elm.children) errors.animation(ErrLoc.A.OBJECT_IS_NOT_ELEMENT, this);
     this._register(elm);
     /*if (elm.children) this._addElems(elm.children);*/
     this.tree.push(elm);
@@ -332,7 +332,7 @@ Animation.prototype.addToTree = function(elm) {
     }
 }*/
 Animation.prototype._register = function(elm) {
-    if (this.hash[elm.id]) errors.animation(ErrLoc.A.ELEMENT_IS_REGISTERED);
+    if (this.hash[elm.id]) errors.animation(ErrLoc.A.ELEMENT_IS_REGISTERED, this);
     elm.registered = true;
     elm.anim = this;
     this.hash[elm.id] = elm;
@@ -352,7 +352,7 @@ Animation.prototype._unregister_no_rm = function(elm) {
 };
 
 Animation.prototype._unregister = function(elm, save_in_tree) { // save_in_tree is optional and false by default
-    if (!elm.registered) errors.animation(ErrLoc.A.ELEMENT_IS_NOT_REGISTERED);
+    if (!elm.registered) errors.animation(ErrLoc.A.ELEMENT_IS_NOT_REGISTERED, this);
     var me = this;
     elm.each(function(child) {
         me._unregister(child);

--- a/src/anm/animation/easing.js
+++ b/src/anm/animation/easing.js
@@ -1,5 +1,6 @@
-var C = require('../constants.js'),
-    CSeg = require('../graphics/segments.js').CSeg;
+var C = require('../constants.js');
+
+var CSeg = require('../graphics/segments.js').CSeg;
 
 // Easings
 // -----------------------------------------------------------------------------

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -177,7 +177,7 @@ Element._customImporters = [];
 provideEvents(Element, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                          C.X_MMOVE, C.X_MOVER, C.X_MOUT,
                          C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                         C.X_START, C.X_STOP, C.X_ERROR,
+                         C.X_START, C.X_STOP,
                          // player events
                          C.S_CHANGE_STATE,
                          C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -1207,16 +1207,16 @@ Element.prototype.modify = function(band, modifier) {
     //           nor painters, they should be accessible through this.t / this.dt
     if (!is.arr(band)) { modifier = band;
                         band = null; }
-    if (!modifier) errors.animation('No modifier was passed to .modify() method');
+    if (!modifier) errors.element('No modifier was passed to .modify() method', this);
     if (!is.modifier(modifier) && is.fun(modifier)) {
         modifier = new Modifier(modifier, C.MOD_USER);
     } else if (!is.modifier(modifier)) {
-        errors.animation('Modifier should be either a function or a Modifier instance');
+        errors.element('Modifier should be either a function or a Modifier instance', this);
     }
-    if (!modifier.type) errors.animation('Modifier should have a type defined');
+    if (!modifier.type) errors.element('Modifier should have a type defined', this);
     if (band) modifier.$band = band;
     if (modifier.__applied_to &&
-        modifier.__applied_to[this.id]) errors.animation('This modifier is already applied to this Element');
+        modifier.__applied_to[this.id]) errors.element('This modifier is already applied to this Element', this);
     if (!this.$modifiers[modifier.type]) this.$modifiers[modifier.type] = [];
     this.$modifiers[modifier.type].push(modifier);
     this.__modifiers_hash[modifier.id] = modifier;
@@ -1238,10 +1238,10 @@ Element.prototype.modify = function(band, modifier) {
 Element.prototype.removeModifier = function(modifier) {
     // FIXME!!!: do not pass time, dt and duration neither to modifiers
     //           nor painters, they should be accessible through this.t / this.dt
-    if (!is.modifier(modifier)) errors.animation('Please pass Modifier instance to removeModifier');
-    if (!this.__modifiers_hash[modifier.id]) errors.animation('Modifier wasn\'t applied to this element');
-    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) errors.animation(ErrLoc.A.MODIFIER_NOT_ATTACHED);
-    //if (this.__modifying) errors.animation("Can't remove modifiers while modifying");
+    if (!is.modifier(modifier)) errors.element('Please pass Modifier instance to removeModifier', this);
+    if (!this.__modifiers_hash[modifier.id]) errors.element('Modifier wasn\'t applied to this element', this);
+    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) errors.element(ErrLoc.A.MODIFIER_NOT_ATTACHED, this);
+    //if (this.__modifying) errors.element("Can't remove modifiers while modifying");
     utils.removeElement(this.__modifiers_hash, modifier.id);
     utils.removeElement(this.$modifiers[modifier.type], modifier);
     utils.removeElement(modifier.__applied_to, this.id);
@@ -1267,15 +1267,15 @@ Element.prototype.removeModifier = function(modifier) {
  * @return {anm.Element} itself
  */
 Element.prototype.paint = function(painter) {
-    if (!painter) errors.animation('No painter was passed to .paint() method');
+    if (!painter) errors.element('No painter was passed to .paint() method', this);
     if (!is.painter(painter) && is.fun(painter)) {
         painter = new Painter(painter, C.MOD_USER);
     } else if (!is.painter(painter)) {
-        errors.animation('Painter should be either a function or a Painter instance');
+        errors.element('Painter should be either a function or a Painter instance', this);
     }
-    if (!painter.type) errors.animation('Painter should have a type defined');
+    if (!painter.type) errors.element('Painter should have a type defined', this);
     if (painter.__applied_to &&
-        painter.__applied_to[this.id]) errors.animation('This painter is already applied to this Element');
+        painter.__applied_to[this.id]) errors.element('This painter is already applied to this Element', this);
     if (!this.$painters[painter.type]) this.$painters[painter.type] = [];
     this.$painters[painter.type].push(painter);
     this.__painters_hash[painter.id] = painter;
@@ -1295,10 +1295,10 @@ Element.prototype.paint = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.removePainter = function(painter) {
-    if (!is.painter(painter)) errors.animation('Please pass Painter instance to removePainter');
-    if (!this.__painters_hash[painter.id]) errors.animation('Painter wasn\'t applied to this element');
-    if (!painter.__applied_to || !painter.__applied_to[this.id]) errors.animation(ErrLoc.A.PAINTER_NOT_ATTACHED);
-    //if (this.__modifying) errors.animation("Can't remove modifiers while modifying");
+    if (!is.painter(painter)) errors.element('Please pass Painter instance to removePainter', this);
+    if (!this.__painters_hash[painter.id]) errors.element('Painter wasn\'t applied to this element', this);
+    if (!painter.__applied_to || !painter.__applied_to[this.id]) errors.element(ErrLoc.A.PAINTER_NOT_ATTACHED, this);
+    //if (this.__modifying) errors.element("Can't remove modifiers while modifying", this);
     utils.removeElement(this.__painters_hash, painter.id);
     utils.removeElement(this.$painters[painter.type], painter);
     utils.removeElement(painter.__applied_to, this.id);
@@ -1324,7 +1324,7 @@ Element.prototype.removePainter = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.tween = function(tween) {
-    if (!is.tween(tween)) errors.animation('Please pass Tween instance to .tween() method');
+    if (!is.tween(tween)) errors.element('Please pass Tween instance to .tween() method', this);
     // tweens are always receiving time as relative time
     // is.finite(duration) && duration ? (t / duration) : 0
     return this.modify(tween);
@@ -1341,7 +1341,7 @@ Element.prototype.tween = function(tween) {
 * @return {anm.Element} itself
 */
 Element.prototype.removeTween = function(tween) {
-    if (!is.tween(tween)) errors.animation('Please pass Tween instance to .removeTween() method');
+    if (!is.tween(tween)) errors.element('Please pass Tween instance to .removeTween() method', this);
     return this.removeModifier(tween);
 };
 
@@ -1387,15 +1387,15 @@ Element.prototype.add = function(arg1, arg2, arg3) {
  * @return {anm.Element} parent, itself
  */
 Element.prototype.remove = function(elm) {
-    if (!elm) errors.animation(ErrLoc.A.NO_ELEMENT_TO_REMOVE);
-    if (this.__safeDetach(elm) === 0) errors.animation(ErrLoc.A.NO_ELEMENT);
+    if (!elm) errors.element(ErrLoc.A.NO_ELEMENT_TO_REMOVE);
+    if (this.__safeDetach(elm) === 0) errors.element(ErrLoc.A.NO_ELEMENT);
     this.invalidate();
     return this;
 };
 
 Element.prototype._unbind = function() {
     if (this.parent.__unsafeToRemove ||
-        this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
+        this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE);
     this.parent = null;
     if (this.anim) this.anim._unregister(this);
     // this.anim should be null after unregistering
@@ -1407,7 +1407,7 @@ Element.prototype._unbind = function() {
  * Detach element from parent, a part of removing process
  */
 Element.prototype.detach = function() {
-    if (this.parent.__safeDetach(this) === 0) errors.animation(ErrLoc.A.ELEMENT_NOT_ATTACHED);
+    if (this.parent.__safeDetach(this) === 0) errors.element(ErrLoc.A.ELEMENT_NOT_ATTACHED, this);
 };
 
 /**
@@ -1486,7 +1486,7 @@ Element.prototype.ltime = function(gtime) {
  * @param {anm.Player} handler.player
  */
 Element.prototype.handlePlayerEvent = function(event, handler) {
-    if (!isPlayerEvent(event)) errors.animation('This method is intended to assign only player-related handles');
+    if (!isPlayerEvent(event)) errors.element('This method is intended to assign only player-related handles', this);
     this.on(event, handler);
 };
 
@@ -1551,7 +1551,7 @@ Element.prototype.inform = function(ltime) {
 Element.prototype.band = function(start, stop) {
     if (!is.defined(start)) return this.lband;
     // FIXME: array bands should not pass
-    // if (is.arr(start)) errors.animation('Band is specified with two numbers, not an array');
+    // if (is.arr(start)) errors.element('Band is specified with two numbers, not an array', this);
     if (is.arr(start)) {
         start = start[0];
         stop = start[1];
@@ -1786,7 +1786,7 @@ Element.prototype.__performDetach = function() {
  * @return {anm.Element} itself
  */
 Element.prototype.clear = function() {
-    if (this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
+    if (this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
     if (!this.rendering) {
         var children = this.children;
         this.children = [];
@@ -2248,7 +2248,7 @@ Element.prototype.asClip = function(band, mode, nrep) {
 };
 
 Element.prototype._addChild = function(elm) {
-    //if (elm.parent) errors.animation('This element already has parent, clone it before adding');
+    //if (elm.parent) errors.element('This element already has parent, clone it before adding', this);
     elm.parent = this;
     elm.level = this.level + 1;
     this.children.push(elm); /* or add elem.id? */
@@ -2390,7 +2390,7 @@ Element.prototype.__checkJump = function(at) {
         this.keys[this.key] : t;
     if (t !== null) {
         if ((t < 0) || (t > duration)) {
-            errors.animation('Failed to calculate jump');
+            errors.element('Failed to calculate jump', this);
         }
         if (!this.__jumpLock) {
             // jump was performed if t or rt or key
@@ -2471,7 +2471,7 @@ Element.prototype.__safeDetach = function(what, _cnt) {
         if (this.rendering || what.rendering) {
             this.__detachQueue.push(what/*pos*/);
         } else {
-            if (this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
+            if (this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
             what._unbind();
             children.splice(pos, 1);
         }
@@ -2517,13 +2517,13 @@ Element.prototype._collectRemoteResources = function(anim, player) {
 
 Element.prototype._loadRemoteResources = function(anim, player) {
     if (player.imagesEnabled && this.$image) {
-        this.$image.load(player.id);
+        this.$image.load(this, player.id);
     }
     if (this.is(C.ET_AUDIO) && player.audioEnabled) {
-        this.$audio.load(player);
+        this.$audio.load(this, player);
     }
     if (this.is(C.ET_VIDEO) && player.videoEnabled) {
-        this.$video.load(player);
+        this.$video.load(this, player);
     }
 };
 

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -924,9 +924,9 @@ Element.prototype.render = function(ctx, gtime, dt) {
             mctx.restore();
             bctx.restore();
         }
+        ctx.restore();
     }
-    // immediately when drawn, element becomes shown,
-    // it is reasonable
+    // immediately after being drawn, element is shown, it is reasonable
     this.shown = drawMe;
     this.__postRender();
     this.rendering = false;

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -177,7 +177,7 @@ Element._customImporters = [];
 provideEvents(Element, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                          C.X_MMOVE, C.X_MOVER, C.X_MOUT,
                          C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                         C.X_DRAW, C.X_START, C.X_STOP,
+                         C.X_START, C.X_STOP,
                          // player events
                          C.S_CHANGE_STATE,
                          C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
@@ -930,7 +930,6 @@ Element.prototype.render = function(ctx, gtime, dt) {
     this.shown = drawMe;
     this.__postRender();
     this.rendering = false;
-    if (drawMe) this.fire(C.X_DRAW,ctx);
     return this;
 };
 

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -1207,16 +1207,16 @@ Element.prototype.modify = function(band, modifier) {
     //           nor painters, they should be accessible through this.t / this.dt
     if (!is.arr(band)) { modifier = band;
                         band = null; }
-    if (!modifier) errors.element('No modifier was passed to .modify() method', this);
+    if (!modifier) throw errors.element('No modifier was passed to .modify() method', this);
     if (!is.modifier(modifier) && is.fun(modifier)) {
         modifier = new Modifier(modifier, C.MOD_USER);
     } else if (!is.modifier(modifier)) {
-        errors.element('Modifier should be either a function or a Modifier instance', this);
+        throw errors.element('Modifier should be either a function or a Modifier instance', this);
     }
-    if (!modifier.type) errors.element('Modifier should have a type defined', this);
+    if (!modifier.type) throw errors.element('Modifier should have a type defined', this);
     if (band) modifier.$band = band;
     if (modifier.__applied_to &&
-        modifier.__applied_to[this.id]) errors.element('This modifier is already applied to this Element', this);
+        modifier.__applied_to[this.id]) throw errors.element('This modifier is already applied to this Element', this);
     if (!this.$modifiers[modifier.type]) this.$modifiers[modifier.type] = [];
     this.$modifiers[modifier.type].push(modifier);
     this.__modifiers_hash[modifier.id] = modifier;
@@ -1238,10 +1238,10 @@ Element.prototype.modify = function(band, modifier) {
 Element.prototype.removeModifier = function(modifier) {
     // FIXME!!!: do not pass time, dt and duration neither to modifiers
     //           nor painters, they should be accessible through this.t / this.dt
-    if (!is.modifier(modifier)) errors.element('Please pass Modifier instance to removeModifier', this);
-    if (!this.__modifiers_hash[modifier.id]) errors.element('Modifier wasn\'t applied to this element', this);
-    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) errors.element(ErrLoc.A.MODIFIER_NOT_ATTACHED, this);
-    //if (this.__modifying) errors.element("Can't remove modifiers while modifying");
+    if (!is.modifier(modifier)) throw errors.element('Please pass Modifier instance to removeModifier', this);
+    if (!this.__modifiers_hash[modifier.id]) throw errors.element('Modifier wasn\'t applied to this element', this);
+    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) throw errors.element(ErrLoc.A.MODIFIER_NOT_ATTACHED, this);
+    //if (this.__modifying) throw errors.element("Can't remove modifiers while modifying");
     utils.removeElement(this.__modifiers_hash, modifier.id);
     utils.removeElement(this.$modifiers[modifier.type], modifier);
     utils.removeElement(modifier.__applied_to, this.id);
@@ -1267,15 +1267,15 @@ Element.prototype.removeModifier = function(modifier) {
  * @return {anm.Element} itself
  */
 Element.prototype.paint = function(painter) {
-    if (!painter) errors.element('No painter was passed to .paint() method', this);
+    if (!painter) throw errors.element('No painter was passed to .paint() method', this);
     if (!is.painter(painter) && is.fun(painter)) {
         painter = new Painter(painter, C.MOD_USER);
     } else if (!is.painter(painter)) {
-        errors.element('Painter should be either a function or a Painter instance', this);
+        throw errors.element('Painter should be either a function or a Painter instance', this);
     }
-    if (!painter.type) errors.element('Painter should have a type defined', this);
+    if (!painter.type) throw errors.element('Painter should have a type defined', this);
     if (painter.__applied_to &&
-        painter.__applied_to[this.id]) errors.element('This painter is already applied to this Element', this);
+        painter.__applied_to[this.id]) throw errors.element('This painter is already applied to this Element', this);
     if (!this.$painters[painter.type]) this.$painters[painter.type] = [];
     this.$painters[painter.type].push(painter);
     this.__painters_hash[painter.id] = painter;
@@ -1295,10 +1295,10 @@ Element.prototype.paint = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.removePainter = function(painter) {
-    if (!is.painter(painter)) errors.element('Please pass Painter instance to removePainter', this);
-    if (!this.__painters_hash[painter.id]) errors.element('Painter wasn\'t applied to this element', this);
-    if (!painter.__applied_to || !painter.__applied_to[this.id]) errors.element(ErrLoc.A.PAINTER_NOT_ATTACHED, this);
-    //if (this.__modifying) errors.element("Can't remove modifiers while modifying", this);
+    if (!is.painter(painter)) throw errors.element('Please pass Painter instance to removePainter', this);
+    if (!this.__painters_hash[painter.id]) throw errors.element('Painter wasn\'t applied to this element', this);
+    if (!painter.__applied_to || !painter.__applied_to[this.id]) throw errors.element(ErrLoc.A.PAINTER_NOT_ATTACHED, this);
+    //if (this.__modifying) throw errors.element("Can't remove modifiers while modifying", this);
     utils.removeElement(this.__painters_hash, painter.id);
     utils.removeElement(this.$painters[painter.type], painter);
     utils.removeElement(painter.__applied_to, this.id);
@@ -1324,7 +1324,7 @@ Element.prototype.removePainter = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.tween = function(tween) {
-    if (!is.tween(tween)) errors.element('Please pass Tween instance to .tween() method', this);
+    if (!is.tween(tween)) throw errors.element('Please pass Tween instance to .tween() method', this);
     // tweens are always receiving time as relative time
     // is.finite(duration) && duration ? (t / duration) : 0
     return this.modify(tween);
@@ -1341,7 +1341,7 @@ Element.prototype.tween = function(tween) {
 * @return {anm.Element} itself
 */
 Element.prototype.removeTween = function(tween) {
-    if (!is.tween(tween)) errors.element('Please pass Tween instance to .removeTween() method', this);
+    if (!is.tween(tween)) throw errors.element('Please pass Tween instance to .removeTween() method', this);
     return this.removeModifier(tween);
 };
 
@@ -1387,15 +1387,15 @@ Element.prototype.add = function(arg1, arg2, arg3) {
  * @return {anm.Element} parent, itself
  */
 Element.prototype.remove = function(elm) {
-    if (!elm) errors.element(ErrLoc.A.NO_ELEMENT_TO_REMOVE);
-    if (this.__safeDetach(elm) === 0) errors.element(ErrLoc.A.NO_ELEMENT);
+    if (!elm) throw errors.element(ErrLoc.A.NO_ELEMENT_TO_REMOVE);
+    if (this.__safeDetach(elm) === 0) throw errors.element(ErrLoc.A.NO_ELEMENT);
     this.invalidate();
     return this;
 };
 
 Element.prototype._unbind = function() {
     if (this.parent.__unsafeToRemove ||
-        this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE);
+        this.__unsafeToRemove) throw errors.element(ErrLoc.A.UNSAFE_TO_REMOVE);
     this.parent = null;
     if (this.anim) this.anim._unregister(this);
     // this.anim should be null after unregistering
@@ -1407,7 +1407,7 @@ Element.prototype._unbind = function() {
  * Detach element from parent, a part of removing process
  */
 Element.prototype.detach = function() {
-    if (this.parent.__safeDetach(this) === 0) errors.element(ErrLoc.A.ELEMENT_NOT_ATTACHED, this);
+    if (this.parent.__safeDetach(this) === 0) throw errors.element(ErrLoc.A.ELEMENT_NOT_ATTACHED, this);
 };
 
 /**
@@ -1486,7 +1486,7 @@ Element.prototype.ltime = function(gtime) {
  * @param {anm.Player} handler.player
  */
 Element.prototype.handlePlayerEvent = function(event, handler) {
-    if (!isPlayerEvent(event)) errors.element('This method is intended to assign only player-related handles', this);
+    if (!isPlayerEvent(event)) throw errors.element('This method is intended to assign only player-related handles', this);
     this.on(event, handler);
 };
 
@@ -1551,7 +1551,7 @@ Element.prototype.inform = function(ltime) {
 Element.prototype.band = function(start, stop) {
     if (!is.defined(start)) return this.lband;
     // FIXME: array bands should not pass
-    // if (is.arr(start)) errors.element('Band is specified with two numbers, not an array', this);
+    // if (is.arr(start)) throw errors.element('Band is specified with two numbers, not an array', this);
     if (is.arr(start)) {
         start = start[0];
         stop = start[1];
@@ -1786,7 +1786,7 @@ Element.prototype.__performDetach = function() {
  * @return {anm.Element} itself
  */
 Element.prototype.clear = function() {
-    if (this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
+    if (this.__unsafeToRemove) throw errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
     if (!this.rendering) {
         var children = this.children;
         this.children = [];
@@ -2248,7 +2248,7 @@ Element.prototype.asClip = function(band, mode, nrep) {
 };
 
 Element.prototype._addChild = function(elm) {
-    //if (elm.parent) errors.element('This element already has parent, clone it before adding', this);
+    //if (elm.parent) throw errors.element('This element already has parent, clone it before adding', this);
     elm.parent = this;
     elm.level = this.level + 1;
     this.children.push(elm); /* or add elem.id? */
@@ -2390,7 +2390,7 @@ Element.prototype.__checkJump = function(at) {
         this.keys[this.key] : t;
     if (t !== null) {
         if ((t < 0) || (t > duration)) {
-            errors.element('Failed to calculate jump', this);
+            throw errors.element('Failed to calculate jump', this);
         }
         if (!this.__jumpLock) {
             // jump was performed if t or rt or key
@@ -2471,7 +2471,7 @@ Element.prototype.__safeDetach = function(what, _cnt) {
         if (this.rendering || what.rendering) {
             this.__detachQueue.push(what/*pos*/);
         } else {
-            if (this.__unsafeToRemove) errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
+            if (this.__unsafeToRemove) throw errors.element(ErrLoc.A.UNSAFE_TO_REMOVE, this);
             what._unbind();
             children.splice(pos, 1);
         }

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -43,16 +43,6 @@ function t_cmp(t0, t1) {
     return 0;
 }
 
-var isPlayerEvent = function(type) {
-    // FIXME: make some marker to group types of events
-    return ((type == C.S_CHANGE_STATE) ||
-            (type == C.S_PLAY)  || (type == C.S_PAUSE)    ||
-            (type == C.S_STOP)  || (type == C.S_REPEAT)   ||
-            (type == C.S_LOAD)  || (type == C.S_RES_LOAD) ||
-            (type == C.S_ERROR) || (type == C.S_IMPORT)   ||
-            (type == C.S_COMPLETE));
-};
-
 Element.DEFAULT_PVT = [ 0.5, 0.5 ];
 Element.DEFAULT_REG = [ 0.0, 0.0 ];
 
@@ -177,11 +167,7 @@ Element._customImporters = [];
 provideEvents(Element, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                          C.X_MMOVE, C.X_MOVER, C.X_MOUT,
                          C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                         C.X_START, C.X_STOP,
-                         // player events
-                         C.S_CHANGE_STATE,
-                         C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
-                         C.S_IMPORT, C.S_LOAD, C.S_RES_LOAD, C.S_ERROR ]);
+                         C.X_START, C.X_STOP ]);
 /**
  * @method is
  *
@@ -1477,20 +1463,6 @@ Element.prototype.ltime = function(gtime) {
 };
 
 /**
- * @private @method handlePlayerEvent
- *
- * Pass player event to this element.
- *
- * @param {C.S_*} event
- * @param {Function} handler
- * @param {anm.Player} handler.player
- */
-Element.prototype.handlePlayerEvent = function(event, handler) {
-    if (!isPlayerEvent(event)) throw errors.element('This method is intended to assign only player-related handles', this);
-    this.on(event, handler);
-};
-
-/**
  * @private @method inform
  *
  * Inform element with `C.X_START` / `C.X_STOP` events, if passed time matches
@@ -2422,8 +2394,7 @@ Element.prototype.__checkJump = function(at) {
     return t;
 }
 Element.prototype.handle__x = function(type, evt) {
-    if (!isPlayerEvent(type) &&
-        (type != C.X_START) &&
+    if ((type != C.X_START) &&
         (type != C.X_STOP)) {
       if (this.shown) {
         this.__saveEvt(type, evt);

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -177,7 +177,7 @@ Element._customImporters = [];
 provideEvents(Element, [ C.X_MCLICK, C.X_MDCLICK, C.X_MUP, C.X_MDOWN,
                          C.X_MMOVE, C.X_MOVER, C.X_MOUT,
                          C.X_KPRESS, C.X_KUP, C.X_KDOWN,
-                         C.X_START, C.X_STOP,
+                         C.X_START, C.X_STOP, C.X_ERROR,
                          // player events
                          C.S_CHANGE_STATE,
                          C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -23,8 +23,8 @@ var Modifier = require('./modifier.js'),
     Painter = require('./painter.js'),
     Bands = require('./band.js');
 
-var AnimationError = require('../errors.js').AnimationError,
-    Errors = require('../loc.js').Errors;
+var errors = require('../errors.js'),
+    ErrLoc = require('../loc.js').Errors;
 
 // Internal Constants
 // -----------------------------------------------------------------------------
@@ -1211,16 +1211,16 @@ Element.prototype.modify = function(band, modifier) {
     //           nor painters, they should be accessible through this.t / this.dt
     if (!is.arr(band)) { modifier = band;
                         band = null; }
-    if (!modifier) throw new AnimationError('No modifier was passed to .modify() method');
+    if (!modifier) errors.animation('No modifier was passed to .modify() method');
     if (!is.modifier(modifier) && is.fun(modifier)) {
         modifier = new Modifier(modifier, C.MOD_USER);
     } else if (!is.modifier(modifier)) {
-        throw new AnimationError('Modifier should be either a function or a Modifier instance');
+        errors.animation('Modifier should be either a function or a Modifier instance');
     }
-    if (!modifier.type) throw new AnimationError('Modifier should have a type defined');
+    if (!modifier.type) errors.animation('Modifier should have a type defined');
     if (band) modifier.$band = band;
     if (modifier.__applied_to &&
-        modifier.__applied_to[this.id]) throw new AnimationError('This modifier is already applied to this Element');
+        modifier.__applied_to[this.id]) errors.animation('This modifier is already applied to this Element');
     if (!this.$modifiers[modifier.type]) this.$modifiers[modifier.type] = [];
     this.$modifiers[modifier.type].push(modifier);
     this.__modifiers_hash[modifier.id] = modifier;
@@ -1242,10 +1242,10 @@ Element.prototype.modify = function(band, modifier) {
 Element.prototype.removeModifier = function(modifier) {
     // FIXME!!!: do not pass time, dt and duration neither to modifiers
     //           nor painters, they should be accessible through this.t / this.dt
-    if (!is.modifier(modifier)) throw new AnimationError('Please pass Modifier instance to removeModifier');
-    if (!this.__modifiers_hash[modifier.id]) throw new AnimationError('Modifier wasn\'t applied to this element');
-    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) throw new AnimationError(Errors.A.MODIFIER_NOT_ATTACHED);
-    //if (this.__modifying) throw new AnimErr("Can't remove modifiers while modifying");
+    if (!is.modifier(modifier)) errors.animation('Please pass Modifier instance to removeModifier');
+    if (!this.__modifiers_hash[modifier.id]) errors.animation('Modifier wasn\'t applied to this element');
+    if (!modifier.__applied_to || !modifier.__applied_to[this.id]) errors.animation(ErrLoc.A.MODIFIER_NOT_ATTACHED);
+    //if (this.__modifying) errors.animation("Can't remove modifiers while modifying");
     utils.removeElement(this.__modifiers_hash, modifier.id);
     utils.removeElement(this.$modifiers[modifier.type], modifier);
     utils.removeElement(modifier.__applied_to, this.id);
@@ -1271,15 +1271,15 @@ Element.prototype.removeModifier = function(modifier) {
  * @return {anm.Element} itself
  */
 Element.prototype.paint = function(painter) {
-    if (!painter) throw new AnimationError('No painter was passed to .paint() method');
+    if (!painter) errors.animation('No painter was passed to .paint() method');
     if (!is.painter(painter) && is.fun(painter)) {
         painter = new Painter(painter, C.MOD_USER);
     } else if (!is.painter(painter)) {
-        throw new AnimationError('Painter should be either a function or a Painter instance');
+        errors.animation('Painter should be either a function or a Painter instance');
     }
-    if (!painter.type) throw new AnimationError('Painter should have a type defined');
+    if (!painter.type) errors.animation('Painter should have a type defined');
     if (painter.__applied_to &&
-        painter.__applied_to[this.id]) throw new AnimationError('This painter is already applied to this Element');
+        painter.__applied_to[this.id]) errors.animation('This painter is already applied to this Element');
     if (!this.$painters[painter.type]) this.$painters[painter.type] = [];
     this.$painters[painter.type].push(painter);
     this.__painters_hash[painter.id] = painter;
@@ -1299,10 +1299,10 @@ Element.prototype.paint = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.removePainter = function(painter) {
-    if (!is.painter(painter)) throw new AnimationError('Please pass Painter instance to removePainter');
-    if (!this.__painters_hash[painter.id]) throw new AnimationError('Painter wasn\'t applied to this element');
-    if (!painter.__applied_to || !painter.__applied_to[this.id]) throw new AnimErr(Errors.A.PAINTER_NOT_ATTACHED);
-    //if (this.__modifying) throw new AnimErr("Can't remove modifiers while modifying");
+    if (!is.painter(painter)) errors.animation('Please pass Painter instance to removePainter');
+    if (!this.__painters_hash[painter.id]) errors.animation('Painter wasn\'t applied to this element');
+    if (!painter.__applied_to || !painter.__applied_to[this.id]) errors.animation(ErrLoc.A.PAINTER_NOT_ATTACHED);
+    //if (this.__modifying) errors.animation("Can't remove modifiers while modifying");
     utils.removeElement(this.__painters_hash, painter.id);
     utils.removeElement(this.$painters[painter.type], painter);
     utils.removeElement(painter.__applied_to, this.id);
@@ -1328,7 +1328,7 @@ Element.prototype.removePainter = function(painter) {
  * @return {anm.Element} itself
  */
 Element.prototype.tween = function(tween) {
-    if (!is.tween(tween)) throw new AnimationError('Please pass Tween instance to .tween() method');
+    if (!is.tween(tween)) errors.animation('Please pass Tween instance to .tween() method');
     // tweens are always receiving time as relative time
     // is.finite(duration) && duration ? (t / duration) : 0
     return this.modify(tween);
@@ -1345,7 +1345,7 @@ Element.prototype.tween = function(tween) {
 * @return {anm.Element} itself
 */
 Element.prototype.removeTween = function(tween) {
-    if (!is.tween(tween)) throw new AnimationError('Please pass Tween instance to .removeTween() method');
+    if (!is.tween(tween)) errors.animation('Please pass Tween instance to .removeTween() method');
     return this.removeModifier(tween);
 };
 
@@ -1391,15 +1391,15 @@ Element.prototype.add = function(arg1, arg2, arg3) {
  * @return {anm.Element} parent, itself
  */
 Element.prototype.remove = function(elm) {
-    if (!elm) throw new AnimationError(Errors.A.NO_ELEMENT_TO_REMOVE);
-    if (this.__safeDetach(elm) === 0) throw new AnimationError(Errors.A.NO_ELEMENT);
+    if (!elm) errors.animation(ErrLoc.A.NO_ELEMENT_TO_REMOVE);
+    if (this.__safeDetach(elm) === 0) errors.animation(ErrLoc.A.NO_ELEMENT);
     this.invalidate();
     return this;
 };
 
 Element.prototype._unbind = function() {
     if (this.parent.__unsafeToRemove ||
-        this.__unsafeToRemove) throw new AnimationError(Errors.A.UNSAFE_TO_REMOVE);
+        this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
     this.parent = null;
     if (this.anim) this.anim._unregister(this);
     // this.anim should be null after unregistering
@@ -1411,7 +1411,7 @@ Element.prototype._unbind = function() {
  * Detach element from parent, a part of removing process
  */
 Element.prototype.detach = function() {
-    if (this.parent.__safeDetach(this) === 0) throw new AnimationError(Errors.A.ELEMENT_NOT_ATTACHED);
+    if (this.parent.__safeDetach(this) === 0) errors.animation(ErrLoc.A.ELEMENT_NOT_ATTACHED);
 };
 
 /**
@@ -1490,7 +1490,7 @@ Element.prototype.ltime = function(gtime) {
  * @param {anm.Player} handler.player
  */
 Element.prototype.handlePlayerEvent = function(event, handler) {
-    if (!isPlayerEvent(event)) throw new Error('This method is intended to assign only player-related handles');
+    if (!isPlayerEvent(event)) errors.animation('This method is intended to assign only player-related handles');
     this.on(event, handler);
 };
 
@@ -1555,7 +1555,7 @@ Element.prototype.inform = function(ltime) {
 Element.prototype.band = function(start, stop) {
     if (!is.defined(start)) return this.lband;
     // FIXME: array bands should not pass
-    // if (is.arr(start)) throw new AnimErr('Band is specified with two numbers, not an array');
+    // if (is.arr(start)) errors.animation('Band is specified with two numbers, not an array');
     if (is.arr(start)) {
         start = start[0];
         stop = start[1];
@@ -1790,7 +1790,7 @@ Element.prototype.__performDetach = function() {
  * @return {anm.Element} itself
  */
 Element.prototype.clear = function() {
-    if (this.__unsafeToRemove) throw new AnimErr(Errors.A.UNSAFE_TO_REMOVE);
+    if (this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
     if (!this.rendering) {
         var children = this.children;
         this.children = [];
@@ -2252,7 +2252,7 @@ Element.prototype.asClip = function(band, mode, nrep) {
 };
 
 Element.prototype._addChild = function(elm) {
-    //if (elm.parent) throw new AnimationError('This element already has parent, clone it before adding');
+    //if (elm.parent) errors.animation('This element already has parent, clone it before adding');
     elm.parent = this;
     elm.level = this.level + 1;
     this.children.push(elm); /* or add elem.id? */
@@ -2394,7 +2394,7 @@ Element.prototype.__checkJump = function(at) {
         this.keys[this.key] : t;
     if (t !== null) {
         if ((t < 0) || (t > duration)) {
-            throw new AnimationError('failed to calculate jump');
+            errors.animation('Failed to calculate jump');
         }
         if (!this.__jumpLock) {
             // jump was performed if t or rt or key
@@ -2475,7 +2475,7 @@ Element.prototype.__safeDetach = function(what, _cnt) {
         if (this.rendering || what.rendering) {
             this.__detachQueue.push(what/*pos*/);
         } else {
-            if (this.__unsafeToRemove) throw new AnimationError(Errors.A.UNSAFE_TO_REMOVE);
+            if (this.__unsafeToRemove) errors.animation(ErrLoc.A.UNSAFE_TO_REMOVE);
             what._unbind();
             children.splice(pos, 1);
         }

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -43,7 +43,7 @@ var errors = require('../errors.js');
  * * `elm.tween(new Tween(C.T_ROTATE, [0, Math.PI / 2]).band(0, 2).easing(anm.C.E_IN))`
  */
 function Tween(tween_type, data) {
-    if (!tween_type) errors.animation('Tween type is required to be specified or function passed');
+    if (!tween_type) errors.element('Tween type is required to be specified or function passed');
     var func;
     if (is.fun(tween_type)) {
         func = tween_type;
@@ -72,7 +72,7 @@ function Tween(tween_type, data) {
 }
 
 var data_block_fn = function() {
-    errors.animation("Data should be passed to tween in a constructor or using from()/to() methods");
+    errors.element("Data should be passed to tween in a constructor or using from()/to() methods");
 };
 
 // TODO: add function to add every tween type in easy way, may be separate module?

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -43,7 +43,7 @@ var errors = require('../errors.js');
  * * `elm.tween(new Tween(C.T_ROTATE, [0, Math.PI / 2]).band(0, 2).easing(anm.C.E_IN))`
  */
 function Tween(tween_type, data) {
-    if (!tween_type) errors.element('Tween type is required to be specified or function passed');
+    if (!tween_type) throw errors.element('Tween type is required to be specified or function passed');
     var func;
     if (is.fun(tween_type)) {
         func = tween_type;
@@ -72,7 +72,7 @@ function Tween(tween_type, data) {
 }
 
 var data_block_fn = function() {
-    errors.element("Data should be passed to tween in a constructor or using from()/to() methods");
+    throw errors.element("Data should be passed to tween in a constructor or using from()/to() methods");
 };
 
 // TODO: add function to add every tween type in easy way, may be separate module?

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -1,8 +1,10 @@
-var C = require('../constants.js'),
-    is = require('../utils.js').is,
-    Modifier = require('./modifier.js'),
-    AnimationError = require('../errors.js').AnimationError,
-    Brush = require('../graphics/brush.js');
+var C = require('../constants.js');
+var is = require('../utils.js').is;
+
+var Modifier = require('./modifier.js');
+var Brush = require('../graphics/brush.js');
+
+var errors = require('../errors.js');
 
 /**
  * @class anm.Tween
@@ -41,7 +43,7 @@ var C = require('../constants.js'),
  * * `elm.tween(new Tween(C.T_ROTATE, [0, Math.PI / 2]).band(0, 2).easing(anm.C.E_IN))`
  */
 function Tween(tween_type, data) {
-    if (!tween_type) throw new Error('Tween type is required to be specified or function passed');
+    if (!tween_type) errors.animation('Tween type is required to be specified or function passed');
     var func;
     if (is.fun(tween_type)) {
         func = tween_type;
@@ -70,7 +72,7 @@ function Tween(tween_type, data) {
 }
 
 var data_block_fn = function() {
-    throw new AnimationError("Data should be passed to tween in a constructor or using from()/to() methods");
+    errors.animation("Data should be passed to tween in a constructor or using from()/to() methods");
 };
 
 // TODO: add function to add every tween type in easy way, may be separate module?

--- a/src/anm/errors.js
+++ b/src/anm/errors.js
@@ -1,4 +1,4 @@
-var C = require('constants.js');
+var C = require('./constants.js');
 
 function __errorAs(name) {
     return function (message) {

--- a/src/anm/errors.js
+++ b/src/anm/errors.js
@@ -7,8 +7,36 @@ function __errorAs(name) {
   };
 }
 
+var SystemError = __errorAs('SystemError'),
+    PlayerError = __errorAs('PlayerError'),
+    AnimationError = __errorAs('AnimationError');
+
+var lastError = null;
+
+// TODO: group errors by Player instance ID
+
+function fire(err) {
+    lastError = err;
+    //console.error(err);
+    throw err;
+}
+
+function last() { return lastError; }
+
+function forget() { lastError = null; }
+
 module.exports = {
-  SystemError:__errorAs('SystemError'),
-  PlayerError: __errorAs('PlayerError'),
-  AnimationError: __errorAs('AnimationError')
+
+  fire: fire,
+  last: last,
+  forget: forget,
+
+  system: function(text) { fire(new SystemError(text)); },
+  player: function(text) { fire(new PlayerError(text)); },
+  animation: function(text) { fire(new AnimationError(text)); },
+
+  SystemError: SystemError,
+  PlayerError: PlayerError,
+  AnimationError: AnimationError
+
 };

--- a/src/anm/errors.js
+++ b/src/anm/errors.js
@@ -1,42 +1,45 @@
+var C = require('constants.js');
+
 function __errorAs(name) {
-  return function (message) {
-      if (Error.captureStackTrace) Error.captureStackTrace(this, this);
-      var err = new Error(message || '');
-      err.name = name;
-      return err;
-  };
+    return function (message) {
+        if (Error.captureStackTrace) Error.captureStackTrace(this, this);
+        var err = new Error(message || '');
+        err.name = name;
+        return err;
+    };
 }
 
 var SystemError = __errorAs('SystemError'),
     PlayerError = __errorAs('PlayerError'),
     AnimationError = __errorAs('AnimationError');
 
-var lastError = null;
-
-// TODO: group errors by Player instance ID
-
-function fire(err) {
-    lastError = err;
-    //console.error(err);
-    throw err;
-}
-
-function last() { return lastError; }
-
-function forget() { lastError = null; }
-
 module.exports = {
 
-  fire: fire,
-  last: last,
-  forget: forget,
+    system: function(text, player) {
+        var err = new SystemError(text);
+        if (player) player.fire(C.S_ERROR, err);
+        throw err;
+    },
+    player: function(text, player) {
+        var err = new PlayerError(text);
+        if (player) player.fire(C.S_ERROR, err);
+        throw err;
+    },
+    animation: function(text, anim) {
+        var err = new AnimationError(text);
+        if (anim) anim.fire(C.X_ERROR, err);
+        throw err;
+    },
+    element: function(text, elm) {
+        var err = new AnimationError(text);
+        if (elm && elm.anim) {
+            elm.anim.fire(C.X_ERROR, err);
+        }
+        throw err;
+    },
 
-  system: function(text) { fire(new SystemError(text)); },
-  player: function(text) { fire(new PlayerError(text)); },
-  animation: function(text) { fire(new AnimationError(text)); },
-
-  SystemError: SystemError,
-  PlayerError: PlayerError,
-  AnimationError: AnimationError
+    SystemError: SystemError,
+    PlayerError: PlayerError,
+    AnimationError: AnimationError
 
 };

--- a/src/anm/errors.js
+++ b/src/anm/errors.js
@@ -18,24 +18,24 @@ module.exports = {
     system: function(text, player) {
         var err = new SystemError(text);
         if (player) player.fire(C.S_ERROR, err);
-        throw err;
+        return err;
     },
     player: function(text, player) {
         var err = new PlayerError(text);
         if (player) player.fire(C.S_ERROR, err);
-        throw err;
+        return err;
     },
     animation: function(text, anim) {
         var err = new AnimationError(text);
         if (anim) anim.fire(C.X_ERROR, err);
-        throw err;
+        return err;
     },
     element: function(text, elm) {
         var err = new AnimationError(text);
         if (elm && elm.anim) {
             elm.anim.fire(C.X_ERROR, err);
         }
-        throw err;
+        return err;
     },
 
     SystemError: SystemError,

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -44,19 +44,25 @@ function provideEvents(subj, events) {
         // FIXME: make it chainable, use handler instance to unbind, instead of index
         return (this.handlers[event].length - 1);
     };
-    subj.prototype.fire = function(event/*, args*/) {
+    subj.prototype.fire = function(event/*, evt_args*/) {
+        if (this.disabled) return;
         if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
         if (!this.provides(event)) errors.system('Event \'' + C.__enmap[event] +
                                                  '\' not provided by ' + this);
-        if (this.disabled) return;
-        var evt_args = Array.prototype.slice.call(arguments, 1);
         if (this.handle__x && !(this.handle__x.apply(this, arguments))) return;
         var name = C.__enmap[event];
-        if (this['handle_'+name]) this['handle_'+name].apply(this, evt_args);
-        var _hdls = this.handlers[event];
-        for (var hi = 0, hl = _hdls.length; hi < hl; hi++) {
-            _hdls[hi].apply(this, evt_args);
+        if (this['handle_'+name] || this.handlers[event].length) {
+            var evt_args = new Array(arguments.length - 1);
+            for (var i = 1; i < arguments.length; i++) {
+                evt_args[i] = arguments[i];
+            }
+            if (this['handle_'+name]) this['handle_'+name].apply(this, evt_args);
+            var _hdls = this.handlers[event];
+            for (var hi = 0, hl = _hdls.length; hi < hl; hi++) {
+                _hdls[hi].apply(this, evt_args);
+            }
         }
+
     };
     subj.prototype.provides = (function(evts) {
         return function(event) {

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -1,5 +1,7 @@
 var C = require('./constants.js');
 
+var errors = require('./errors.js');
+
 // Events
 // -----------------------------------------------------------------------------
 C.__enmap = {};
@@ -33,19 +35,19 @@ function provideEvents(subj, events) {
         };
     })(events);
     subj.prototype.on = function(event, handler) {
-        if (!this.handlers) throw new Error('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) throw new Error('Event \'' + C.__enmap[event] +
-                                                     '\' not provided by ' + this);
-        if (!handler) throw new Error('You are trying to assign ' +
-                                        'undefined handler for event ' + event);
+        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) errors.system('Event \'' + C.__enmap[event] +
+                                                 '\' not provided by ' + this);
+        if (!handler) errors.system('You are trying to assign ' +
+                                    'undefined handler for event ' + event);
         this.handlers[event].push(handler);
         // FIXME: make it chainable, use handler instance to unbind, instead of index
         return (this.handlers[event].length - 1);
     };
     subj.prototype.fire = function(event/*, args*/) {
-        if (!this.handlers) throw new Error('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) throw new Error('Event \'' + C.__enmap[event] +
-                                                     '\' not provided by ' + this);
+        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) errors.system('Event \'' + C.__enmap[event] +
+                                                 '\' not provided by ' + this);
         if (this.disabled) return;
         var evt_args = Array.prototype.slice.call(arguments, 1);
         if (this.handle__x && !(this.handle__x.apply(this, arguments))) return;
@@ -58,23 +60,23 @@ function provideEvents(subj, events) {
     };
     subj.prototype.provides = (function(evts) {
         return function(event) {
-            if (!this.handlers) throw new Error('Instance is not initialized with handlers, call __initHandlers in its constructor');
+            if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
             if (!event) return evts;
             return this.handlers.hasOwnProperty(event);
         };
     })(events);
     subj.prototype.unbind = function(event, idx) {
-        if (!this.handlers) throw new Error('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) throw new Error('Event ' + event +
-                                                     ' not provided by ' + this);
+        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) errors.system('Event ' + event +
+                                                 ' not provided by ' + this);
         if (this.handlers[event][idx]) {
             this.handlers[event].splice(idx, 1);
         } else {
-            throw new Error('No such handler ' + idx + ' for event ' + event);
+            errors.system('No such handler ' + idx + ' for event ' + event);
         }
     };
     subj.prototype.disposeHandlers = function() {
-        if (!this.handlers) throw new Error('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
         var _hdls = this.handlers;
         for (var evt in _hdls) {
             if (_hdls.hasOwnProperty(evt)) _hdls[evt] = [];

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -35,10 +35,10 @@ function provideEvents(subj, events) {
         };
     })(events);
     subj.prototype.on = function(event, handler) {
-        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) errors.system('Event \'' + C.__enmap[event] +
+        if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) throw errors.system('Event \'' + C.__enmap[event] +
                                                  '\' not provided by ' + this);
-        if (!handler) errors.system('You are trying to assign ' +
+        if (!handler) throw errors.system('You are trying to assign ' +
                                     'undefined handler for event ' + event);
         this.handlers[event].push(handler);
         // FIXME: make it chainable, use handler instance to unbind, instead of index
@@ -46,8 +46,8 @@ function provideEvents(subj, events) {
     };
     subj.prototype.fire = function(event/*, evt_args*/) {
         if (this.disabled) return;
-        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) errors.system('Event \'' + C.__enmap[event] +
+        if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) throw errors.system('Event \'' + C.__enmap[event] +
                                                  '\' not provided by ' + this);
         if (this.handle__x && !(this.handle__x.apply(this, arguments))) return;
         var name = C.__enmap[event];
@@ -66,23 +66,23 @@ function provideEvents(subj, events) {
     };
     subj.prototype.provides = (function(evts) {
         return function(event) {
-            if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+            if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
             if (!event) return evts;
             return this.handlers.hasOwnProperty(event);
         };
     })(events);
     subj.prototype.unbind = function(event, idx) {
-        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
-        if (!this.provides(event)) errors.system('Event ' + event +
+        if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.provides(event)) throw errors.system('Event ' + event +
                                                  ' not provided by ' + this);
         if (this.handlers[event][idx]) {
             this.handlers[event].splice(idx, 1);
         } else {
-            errors.system('No such handler ' + idx + ' for event ' + event);
+            throw errors.system('No such handler ' + idx + ' for event ' + event);
         }
     };
     subj.prototype.disposeHandlers = function() {
-        if (!this.handlers) errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
+        if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
         var _hdls = this.handlers;
         for (var evt in _hdls) {
             if (_hdls.hasOwnProperty(evt)) _hdls[evt] = [];

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -110,7 +110,7 @@ registerEvent('S_PLAYER_DETACH', 'player_detach', 'player_detach');
 // NB: All of the events must have different values, or the flow will be broken
 // FIXME: allow grouping events, i.e. value may a group_marker + name of an event
 //        also, allow events to belong to several groups, it may replace a tests like
-//        XT_MOUSE or XT_CONTROL or isPlayerEvent
+//        XT_MOUSE or XT_CONTROL
 
 // * mouse
 registerEvent('X_MCLICK', 'mclick', 1);

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -54,7 +54,7 @@ function provideEvents(subj, events) {
         if (this['handle_'+name] || this.handlers[event].length) {
             var evt_args = new Array(arguments.length - 1);
             for (var i = 1; i < arguments.length; i++) {
-                evt_args[i] = arguments[i];
+                evt_args[i - 1] = arguments[i];
             }
             if (this['handle_'+name]) this['handle_'+name].apply(this, evt_args);
             var _hdls = this.handlers[event];

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -129,8 +129,7 @@ registerEvent('X_KPRESS', 'kpress', 128);
 registerEvent('X_KUP', 'kup', 256);
 registerEvent('X_KDOWN', 'kdown', 1024);
 
-registerEvent('XT_KEYBOARD', 'keyboard',
-  (C.X_KPRESS | C.X_KUP | C.X_KDOWN));
+registerEvent('XT_KEYBOARD', 'keyboard', (C.X_KPRESS | C.X_KUP | C.X_KDOWN));
 
 // * controllers
 registerEvent('XT_CONTROL', 'control', (C.XT_KEYBOARD | C.XT_MOUSE));
@@ -138,6 +137,9 @@ registerEvent('XT_CONTROL', 'control', (C.XT_KEYBOARD | C.XT_MOUSE));
 // * bands
 registerEvent('X_START', 'start', 'x_start');
 registerEvent('X_STOP', 'stop', 'x_stop');
+
+// * Animation or Element error
+registerEvent('X_ERROR', 'error', 'x_error');
 
 // * playing (player state)
 registerEvent('S_PLAY', 'play', 'play');
@@ -148,7 +150,7 @@ registerEvent('S_REPEAT', 'repeat', 'repeat');
 registerEvent('S_IMPORT', 'import', 'import');
 registerEvent('S_LOAD', 'load', 'load');
 registerEvent('S_RES_LOAD', 'res_load', 'res_load');
-registerEvent('S_ERROR', 'error', 'error');
+registerEvent('S_ERROR', 'error', 'error'); // Player error
 
 
 module.exports = {

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -135,9 +135,6 @@ registerEvent('XT_KEYBOARD', 'keyboard',
 // * controllers
 registerEvent('XT_CONTROL', 'control', (C.XT_KEYBOARD | C.XT_MOUSE));
 
-// * draw
-registerEvent('X_DRAW', 'draw', 'draw');
-
 // * bands
 registerEvent('X_START', 'start', 'x_start');
 registerEvent('X_STOP', 'stop', 'x_stop');

--- a/src/anm/graphics/brush.js
+++ b/src/anm/graphics/brush.js
@@ -354,8 +354,8 @@ Brush.value = function(value, target) {
                     brush[key] = value[key];
                 }
             }
-        } else errors.animation('Unknown type of brush');
-    } else errors.animation('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
+        } else errors.element('Unknown type of brush');
+    } else errors.element('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
 };
 
 Brush.grad = function(stops, bounds, dir) {

--- a/src/anm/graphics/brush.js
+++ b/src/anm/graphics/brush.js
@@ -354,8 +354,8 @@ Brush.value = function(value, target) {
                     brush[key] = value[key];
                 }
             }
-        } else errors.element('Unknown type of brush');
-    } else errors.element('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
+        } else throw errors.element('Unknown type of brush');
+    } else throw errors.element('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
 };
 
 Brush.grad = function(stops, bounds, dir) {

--- a/src/anm/graphics/brush.js
+++ b/src/anm/graphics/brush.js
@@ -1,10 +1,14 @@
-var Color = require('./color.js'),
-    C = require('../constants.js'),
-    conf = require('../conf.js'),
+var C = require('../constants.js');
+
+var conf = require('../conf.js'),
     utils = require('../utils.js'),
-    is = utils.is,
-    engine = require('engine'),
-    AnimationError = require('../errors.js').AnimationError;
+    is = utils.is;
+
+var engine = require('engine');
+
+var errors = require('../errors.js');
+
+var Color = require('./color.js');
 
 // Brush
 // -----------------------------------------------------------------------------
@@ -350,8 +354,8 @@ Brush.value = function(value, target) {
                     brush[key] = value[key];
                 }
             }
-        } else throw new AnimationError('Unknown type of brush');
-    } else throw new AnimationError('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
+        } else errors.animation('Unknown type of brush');
+    } else errors.animation('Use Brush.fill, Brush.stroke or Brush.shadow to create brush from values');
 };
 
 Brush.grad = function(stops, bounds, dir) {

--- a/src/anm/graphics/sheet.js
+++ b/src/anm/graphics/sheet.js
@@ -52,9 +52,9 @@ var https = engine.isHttps;
 /**
 * @private @method load
 */
-Sheet.prototype.load = function(player_id, callback, errback) {
+Sheet.prototype.load = function(elm, player_id, callback, errback) {
     callback = callback || this._callback;
-    if (this._image) errors.animation('Image already loaded'); // just skip loading?
+    if (this._image) errors.element('Image already loaded', elm); // just skip loading?
     var me = this;
     if (!me.src) {
         log.error('Empty source URL for image');

--- a/src/anm/graphics/sheet.js
+++ b/src/anm/graphics/sheet.js
@@ -4,6 +4,8 @@ var conf = require('../conf.js'),
 var engine = require('engine'),
     resMan = require('../resource_manager.js');
 
+var errors = require('../errors.js');
+
 var Bounds = require('./bounds.js');
 
 Sheet.instances = 0;
@@ -52,7 +54,7 @@ var https = engine.isHttps;
 */
 Sheet.prototype.load = function(player_id, callback, errback) {
     callback = callback || this._callback;
-    if (this._image) throw new Error('Already loaded'); // just skip loading?
+    if (this._image) errors.animation('Image already loaded'); // just skip loading?
     var me = this;
     if (!me.src) {
         log.error('Empty source URL for image');

--- a/src/anm/graphics/sheet.js
+++ b/src/anm/graphics/sheet.js
@@ -54,7 +54,7 @@ var https = engine.isHttps;
 */
 Sheet.prototype.load = function(elm, player_id, callback, errback) {
     callback = callback || this._callback;
-    if (this._image) errors.element('Image already loaded', elm); // just skip loading?
+    if (this._image) throw errors.element('Image already loaded', elm); // just skip loading?
     var me = this;
     if (!me.src) {
         log.error('Empty source URL for image');
@@ -99,7 +99,8 @@ Sheet.prototype.load = function(elm, player_id, callback, errback) {
         function(err) { log.error(err.srcElement || err.path, err.message || err);
                         me.ready = true;
                         me.wasError = true;
-                        if (errback) errback.call(me, err); });
+                        if (errback) errback.call(me, err);
+                        throw errors.element(err ? err.message : 'Unknown', elm); });
 };
 /**
  * @private @method updateRegion

--- a/src/anm/graphics/text.js
+++ b/src/anm/graphics/text.js
@@ -228,7 +228,7 @@ Text.prototype.invalidate = function() {
 Text.prototype.reset = function() { };
 Text.prototype.dispose = function() { };
 Text.bounds = function(spec, lines) {
-    if (!Text.__measuring_f) errors.system('no Text buffer, bounds call failed');
+    if (!Text.__measuring_f) throw errors.system('no Text buffer, bounds call failed');
     var dimen = Text.__measuring_f(spec, lines);
     return new Bounds(0, 0, dimen[0], dimen[1]);
 };

--- a/src/anm/graphics/text.js
+++ b/src/anm/graphics/text.js
@@ -1,12 +1,12 @@
 var C = require('../constants.js'),
-    is = require('../utils.js').is,
-    SystemError = require('../errors.js').SystemError;
+    is = require('../utils.js').is;
+
+var errors = require('../errors.js');
 
 var engine = require('engine');
 
-var Brush = require('./brush.js');
-
-var Bounds = require('./bounds.js');
+var Brush = require('./brush.js'),
+    Bounds = require('./bounds.js');
 
 // TODO: new Text("My Text").font("Arial").size(5).bold()
 
@@ -228,7 +228,7 @@ Text.prototype.invalidate = function() {
 Text.prototype.reset = function() { };
 Text.prototype.dispose = function() { };
 Text.bounds = function(spec, lines) {
-    if (!Text.__measuring_f) throw new SysErr('no Text buffer, bounds call failed');
+    if (!Text.__measuring_f) errors.system('no Text buffer, bounds call failed');
     var dimen = Text.__measuring_f(spec, lines);
     return new Bounds(0, 0, dimen[0], dimen[1]);
 };

--- a/src/anm/importers.js
+++ b/src/anm/importers.js
@@ -1,9 +1,11 @@
+var errors = require('./errors.js');
+
 // Importers
 // -----------------------------------------------------------------------------
 var importers = {};
 
 importers.register = function(alias, conf) {
-  if (importers[alias]) throw new Error('Importer ' + alias + ' is already registered!');
+  if (importers[alias]) errors.system('Importer ' + alias + ' is already registered!');
   importers[alias] = conf;
 };
 

--- a/src/anm/importers.js
+++ b/src/anm/importers.js
@@ -5,7 +5,7 @@ var errors = require('./errors.js');
 var importers = {};
 
 importers.register = function(alias, conf) {
-  if (importers[alias]) errors.system('Importer ' + alias + ' is already registered!');
+  if (importers[alias]) throw errors.system('Importer ' + alias + ' is already registered!');
   importers[alias] = conf;
 };
 

--- a/src/anm/loader.js
+++ b/src/anm/loader.js
@@ -15,7 +15,7 @@ var Animation = require('./animation/animation.js');
 var Loader = {};
 
 Loader.loadFromUrl = function(player, url, importer, callback) {
-    if (!JSON) errors.system(ErrLoc.S.NO_JSON_PARSER, player);
+    if (!JSON) throw errors.system(ErrLoc.S.NO_JSON_PARSER, player);
 
     mporter = importer || anm.importers.create('animatron');
 
@@ -31,8 +31,8 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
     }
 
     var failure = function(err) {
-        errors.system(utils.strf(ErrLoc.P.SNAPSHOT_LOADING_FAILED,
-                      [ (err ? (err.message || err) : '¿Por qué?') ]));
+        throw errors.system(utils.strf(ErrLoc.P.SNAPSHOT_LOADING_FAILED,
+                            [ (err ? (err.message || err) : '¿Por qué?') ]));
     };
 
     var success = function(req) {
@@ -51,7 +51,7 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
 };
 
 Loader.loadFromObj = function(player, object, importer, callback) {
-    if (!importer) errors.player(ErrLoc.P.NO_IMPORTER_TO_LOAD_WITH, player);
+    if (!importer) throw errors.player(ErrLoc.P.NO_IMPORTER_TO_LOAD_WITH, player);
     var anim = importer.load(object);
     player.fire(C.S_IMPORT, importer, anim, object);
     Loader.loadAnimation(player, anim, callback);

--- a/src/anm/loader.js
+++ b/src/anm/loader.js
@@ -2,10 +2,8 @@ var utils = require('./utils.js'),
     is = utils.is;
 
 var loc = require('./loc.js'),
-    Errors = loc.Errors,
-    errors = require('./errors.js'),
-    SystemError = errors.SystemError,
-    PlayerError = errors.PlayerError;
+    ErrLoc = loc.Errors,
+    errors = require('./errors.js');
 
 var C = require('./constants.js'),
     global_opts = require('./global_opts.js');
@@ -17,7 +15,7 @@ var Animation = require('./animation/animation.js');
 var Loader = {};
 
 Loader.loadFromUrl = function(player, url, importer, callback) {
-    if (!JSON) throw new SystemError(Errors.S.NO_JSON_PARSER);
+    if (!JSON) errors.system(ErrLoc.S.NO_JSON_PARSER);
 
     mporter = importer || anm.importers.create('animatron');
 
@@ -33,8 +31,8 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
     }
 
     var failure = player.__defAsyncSafe(function(err) {
-        throw new SystemError(utils.strf(Errors.P.SNAPSHOT_LOADING_FAILED,
-                               [ (err ? (err.message || err) : '¿Por qué?') ]));
+        errors.system(utils.strf(ErrLoc.P.SNAPSHOT_LOADING_FAILED,
+                      [ (err ? (err.message || err) : '¿Por qué?') ]));
     });
 
     var success = function(req) {
@@ -53,7 +51,7 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
 };
 
 Loader.loadFromObj = function(player, object, importer, callback) {
-    if (!importer) throw new PlayerError(Errors.P.NO_IMPORTER_TO_LOAD_WITH);
+    if (!importer) errors.player(ErrLoc.P.NO_IMPORTER_TO_LOAD_WITH);
     var anim = importer.load(object);
     player.fire(C.S_IMPORT, importer, anim, object);
     Loader.loadAnimation(player, anim, callback);

--- a/src/anm/loader.js
+++ b/src/anm/loader.js
@@ -60,8 +60,9 @@ Loader.loadFromObj = function(player, object, importer, callback) {
 Loader.loadAnimation = function(player, anim, callback) {
     if (player.anim) player.anim.dispose();
     // add debug rendering
-    if (player.debug && !global_opts.liveDebug)
+    if (player.debug && !global_opts.liveDebug) {
         anim.visitElems(function(e) {e.addDebugRender();}); /* FIXME: ensure not to add twice */
+    }
     if (!anim.width || !anim.height) {
         anim.width = player.width;
         anim.height = player.height;

--- a/src/anm/loader.js
+++ b/src/anm/loader.js
@@ -15,7 +15,7 @@ var Animation = require('./animation/animation.js');
 var Loader = {};
 
 Loader.loadFromUrl = function(player, url, importer, callback) {
-    if (!JSON) errors.system(ErrLoc.S.NO_JSON_PARSER);
+    if (!JSON) errors.system(ErrLoc.S.NO_JSON_PARSER, player);
 
     mporter = importer || anm.importers.create('animatron');
 
@@ -51,7 +51,7 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
 };
 
 Loader.loadFromObj = function(player, object, importer, callback) {
-    if (!importer) errors.player(ErrLoc.P.NO_IMPORTER_TO_LOAD_WITH);
+    if (!importer) errors.player(ErrLoc.P.NO_IMPORTER_TO_LOAD_WITH, player);
     var anim = importer.load(object);
     player.fire(C.S_IMPORT, importer, anim, object);
     Loader.loadAnimation(player, anim, callback);

--- a/src/anm/loader.js
+++ b/src/anm/loader.js
@@ -30,10 +30,10 @@ Loader.loadFromUrl = function(player, url, importer, callback) {
         player._checkOpts();
     }
 
-    var failure = player.__defAsyncSafe(function(err) {
+    var failure = function(err) {
         errors.system(utils.strf(ErrLoc.P.SNAPSHOT_LOADING_FAILED,
                       [ (err ? (err.message || err) : '¿Por qué?') ]));
-    });
+    };
 
     var success = function(req) {
         try {

--- a/src/anm/loc.js
+++ b/src/anm/loc.js
@@ -52,6 +52,7 @@ Errors.P.INIT_AFTER_LOAD = 'Initialization was called after loading a animation'
 Errors.P.SNAPSHOT_LOADING_FAILED = 'Snapshot failed to load ({0})';
 Errors.P.IMPORTER_CONSTRUCTOR_PASSED = 'You\'ve passed importer constructor to snapshot loader, but not an instance! ' +
                                        'Probably you used anm.importers.get instead of anm.importers.create.';
+Errors.A.OBJECT_IS_NOT_ELEMENT = 'It appears that you\'ve passed not an instance of anm.Element';
 Errors.A.ELEMENT_IS_REGISTERED = 'This element is already registered in animation';
 Errors.A.ELEMENT_IS_NOT_REGISTERED = 'There is no such element registered in animation';
 Errors.A.UNSAFE_TO_REMOVE = 'Unsafe to remove, please use iterator-based looping (with returning false from iterating function) to remove safely';

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -4,6 +4,8 @@ var conf = require('../conf.js'),
 
 var C = require('../constants.js');
 
+var errors = require('../errors.js');
+
 var engine = require('engine');
 
 var ResMan = require('../resource_manager.js');
@@ -53,7 +55,7 @@ function Audio(url) {
     this.audio = null;
 }
 /** @private @method load */
-Audio.prototype.load = function(player) {
+Audio.prototype.load = function(elm, player) {
     var me = this;
     ResMan.loadOrGet(player.id, me.url,
       function(notify_success, notify_error, notify_progress) { // loader
@@ -194,6 +196,7 @@ Audio.prototype.load = function(player) {
       },
       function(err) {
           log.error(err ? (err.message || err) : 'Unknown error');
+          errors.element(err ? err.message : 'Unknown', elm);
       });
 };
 /** @private @method play */

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -196,7 +196,7 @@ Audio.prototype.load = function(elm, player) {
       },
       function(err) {
           log.error(err ? (err.message || err) : 'Unknown error');
-          errors.element(err ? err.message : 'Unknown', elm);
+          throw errors.element(err ? err.message : 'Unknown', elm);
       });
 };
 /** @private @method play */

--- a/src/anm/media/video.js
+++ b/src/anm/media/video.js
@@ -118,7 +118,7 @@ Video.prototype.load = function(elm, player) {
             me.ready = true;
         },
         function(err) { log.error(err ? (err.message || err) : 'Unknown error');
-                        errors.element(err ? err.message : 'Unknown', elm);
+                        throw errors.element(err ? err.message : 'Unknown', elm);
                         /* throw err; */
         });
 };

--- a/src/anm/media/video.js
+++ b/src/anm/media/video.js
@@ -12,6 +12,8 @@ var conf = require('../conf.js'),
 
 var C = require('../constants.js');
 
+var errors = require('../errors.js');
+
 var engine = require('engine');
 
 var ResMan = require('../resource_manager.js');
@@ -36,7 +38,7 @@ Video.prototype.connect = function(element) {
     element.on(C.S_PAUSE, stop);
 };
 /** @private @method load */
-Video.prototype.load = function(player) {
+Video.prototype.load = function(elm, player) {
 
     var me = this;
     ResMan.loadOrGet(player.id, me.url,
@@ -116,6 +118,7 @@ Video.prototype.load = function(player) {
             me.ready = true;
         },
         function(err) { log.error(err ? (err.message || err) : 'Unknown error');
+                        errors.element(err ? err.message : 'Unknown', elm);
                         /* throw err; */
         });
 };

--- a/src/anm/modules.js
+++ b/src/anm/modules.js
@@ -5,7 +5,7 @@ var errors = require('./errors.js');
 var modules = {};
 
 modules.register = function(alias, conf) {
-  if (modules[alias]) errors.system('Module ' + alias + ' is already registered!');
+  if (modules[alias]) throw errors.system('Module ' + alias + ' is already registered!');
   modules[alias] = conf;
 };
 

--- a/src/anm/modules.js
+++ b/src/anm/modules.js
@@ -1,9 +1,11 @@
+var errors = require('./errors.js');
+
 // Modules
 // -----------------------------------------------------------------------------
 var modules = {};
 
 modules.register = function(alias, conf) {
-  if (modules[alias]) throw new Error('Module ' + alias + ' is already registered!');
+  if (modules[alias]) errors.system('Module ' + alias + ' is already registered!');
   modules[alias] = conf;
 };
 

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -216,8 +216,7 @@ Player.EMPTY_STROKE_WIDTH = 3;
  */
 
 Player.prototype.init = function(elm, opts) {
-    var me = this;
-    this.on(C.S_ERROR, me.__onerror());
+    this.on(C.S_ERROR, this.__onerror());
     if (this.canvas || this.wrapper) throw errors.player(ErrLoc.P.INIT_TWICE, this);
     if (this.anim) throw errors.player(ErrLoc.P.INIT_AFTER_LOAD, this);
     this._initHandlers(); /* TODO: make automatic */

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -216,10 +216,10 @@ Player.EMPTY_STROKE_WIDTH = 3;
  */
 
 Player.prototype.init = function(elm, opts) {
+    this._initHandlers(); /* TODO: make automatic */
     this.on(C.S_ERROR, this.__onerror());
     if (this.canvas || this.wrapper) throw errors.player(ErrLoc.P.INIT_TWICE, this);
     if (this.anim) throw errors.player(ErrLoc.P.INIT_AFTER_LOAD, this);
-    this._initHandlers(); /* TODO: make automatic */
     this._prepare(elm);
     this._addOpts(Player.DEFAULT_CONFIGURATION);
     this._addOpts(engine.extractUserOptions(this.canvas));

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -29,11 +29,9 @@ var utils = require('./utils.js'),
     provideEvents = events.provideEvents;
 
 var loc = require('./loc.js'),
-    Strings = loc.Strings,
-    Errors = loc.Errors,
-    errors = require('./errors.js'),
-    PlayerError = errors.PlayerError,
-    SystemError = errors.SystemError;
+    StrLoc = loc.Strings,
+    ErrLoc = loc.Errors,
+    errors = require('./errors.js');
 
 var engine = require('engine'),
     resourceManager = require('./resource_manager.js'),
@@ -228,8 +226,8 @@ Player._SAFE_METHODS = [ 'init', 'load', 'play', 'stop', 'pause', 'drawAt' ];
  */
 
 Player.prototype.init = function(elm, opts) {
-    if (this.canvas || this.wrapper) throw new PlayerError(Errors.P.INIT_TWICE);
-    if (this.anim) throw new PlayerError(Errors.P.INIT_AFTER_LOAD);
+    if (this.canvas || this.wrapper) errors.player(ErrLoc.P.INIT_TWICE);
+    if (this.anim) errors.player(ErrLoc.P.INIT_AFTER_LOAD);
     this._initHandlers(); /* TODO: make automatic */
     this._prepare(elm);
     this._addOpts(Player.DEFAULT_CONFIGURATION);
@@ -278,7 +276,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
 
     if ((state.happens === C.PLAYING) ||
         (state.happens === C.PAUSED)) {
-        throw new PlayerError(Errors.P.COULD_NOT_LOAD_WHILE_PLAYING);
+        errors.player(ErrLoc.P.COULD_NOT_LOAD_WHILE_PLAYING);
     }
 
     /* object */
@@ -305,7 +303,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
     //        we can't let ourselves create an importer instance manually here,
     //        so it's considered a problem of naming.
     if ((arg2 && arg2.IMPORTER_ID) || (arg3 && arg3.IMPORTER_ID)) {
-        throw new PlayerError(Errors.P.IMPORTER_CONSTRUCTOR_PASSED);
+        errors.player(ErrLoc.P.IMPORTER_CONSTRUCTOR_PASSED);
     }
 
     if (is.fun(arg2)) { callback = arg2; } /* object, callback */
@@ -329,7 +327,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                              // it was requested after the call to 'play', or else it was called by user
                              // FIXME: may be playLock was set by player and user calls this method
                              //        while some animation is already loading
-        if (player._postponedLoad) throw new PlayerError(Errors.P.LOAD_WAS_ALREADY_POSTPONED);
+        if (player._postponedLoad) errors.player(ErrLoc.P.LOAD_WAS_ALREADY_POSTPONED);
         player._lastReceivedAnimationId = null;
         // this kind of postponed call is different from the ones below (_clearPostpones and _postpone),
         // since this one is related to loading mode, rather than calling later some methods which
@@ -346,10 +344,10 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
         player.anim = null;
         player._reset();
         player.stop();
-        throw new PlayerError(Errors.P.NO_ANIMATION_PASSED);
+        errors.player(ErrLoc.P.NO_ANIMATION_PASSED);
     }
 
-    if (!player.__canvasPrepared) throw new PlayerError(Errors.P.CANVAS_NOT_PREPARED);
+    if (!player.__canvasPrepared) errors.player(ErrLoc.P.CANVAS_NOT_PREPARED);
 
     player._reset();
 
@@ -382,7 +380,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
             // subscribe to wait until remote resources will be ready or failed
             resourceManager.subscribe(player.id, remotes, [ player.__defAsyncSafe(
                 function(res_results, err_count) {
-                    //if (err_count) throw new AnimErr(Errors.A.RESOURCES_FAILED_TO_LOAD);
+                    //if (err_count) errors.animation(ErrLoc.A.RESOURCES_FAILED_TO_LOAD);
                     if (player.anim === result) { // avoid race condition when there were two requests
                         // to load different animations and first one finished loading
                         // after the second one
@@ -476,7 +474,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
 
     if (state.happens === C.PLAYING) {
         if (player.infiniteDuration) return; // it's ok to skip this call if it's some dynamic animation (FIXME?)
-        else throw new PlayerError(Errors.P.ALREADY_PLAYING);
+        else errors.player(ErrLoc.P.ALREADY_PLAYING);
     }
 
     if ((player.loadingMode === C.LM_ONPLAY) && !player._lastReceivedAnimationId) {
@@ -486,7 +484,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
         player._playLock = true;
         var loadArgs = player._postponedLoad,
             playArgs = arguments;
-        if (!loadArgs) throw new PlayerError(Errors.P.NO_LOAD_CALL_BEFORE_PLAY);
+        if (!loadArgs) errors.player(ErrLoc.P.NO_LOAD_CALL_BEFORE_PLAY);
         var loadCallback = loadArgs[3];
         var afterLoad = function() {
             if (loadCallback) loadCallback.call(player, arguments);
@@ -527,7 +525,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
                      : (anim.duration || (anim.isEmpty() ? 0
                                                            : Animation.DEFAULT_DURATION));
 
-    if (state.duration === undefined) throw new PlayerError(Errors.P.DURATION_IS_NOT_KNOWN);
+    if (state.duration === undefined) ErrLoc. new PlayerError(ErrLoc.P.DURATION_IS_NOT_KNOWN);
 
     state.__startTime = Date.now();
     state.__redraws = 0;
@@ -647,7 +645,7 @@ Player.prototype.pause = function() {
 
     var state = player.state;
     if (state.happens === C.STOPPED) {
-        throw new PlayerError(Errors.P.PAUSING_WHEN_STOPPED);
+        errors.player(ErrLoc.P.PAUSING_WHEN_STOPPED);
     }
 
     if (state.happens === C.PLAYING) {
@@ -693,12 +691,12 @@ provideEvents(Player, [ C.S_IMPORT, C.S_CHANGE_STATE, C.S_LOAD, C.S_RES_LOAD,
                         C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
                         C.S_ERROR ]);
 Player.prototype._prepare = function(elm) {
-    if (!elm) throw new PlayerError(Errors.P.NO_WRAPPER_PASSED);
+    if (!elm) errors.player(ErrLoc.P.NO_WRAPPER_PASSED);
     var wrapper_id, wrapper;
     if (is.str(elm)) {
         wrapper_id = elm;
         wrapper = engine.getElementById(wrapper_id);
-        if (!wrapper_id) throw new PlayerError(utils.strf(Errors.P.NO_WRAPPER_WITH_ID, [wrapper_id]));
+        if (!wrapper_id) errors.player(utils.strf(ErrLoc.P.NO_WRAPPER_WITH_ID, [wrapper_id]));
     } else {
         if (!elm.id) elm.id = ('anm-player-' + Player.__instances);
         wrapper_id = elm.id;
@@ -708,7 +706,7 @@ Player.prototype._prepare = function(elm) {
     this.id = assign_data.id;
     this.wrapper = assign_data.wrapper;
     this.canvas = assign_data.canvas;
-    if (!engine.checkPlayerCanvas(this.canvas)) throw new PlayerError(Errors.P.CANVAS_NOT_VERIFIED);
+    if (!engine.checkPlayerCanvas(this.canvas)) errors.player(ErrLoc.P.CANVAS_NOT_VERIFIED);
     this.ctx = engine.getContext(this.canvas, '2d');
     this.state = Player.createState(this);
     this.fire(C.S_CHANGE_STATE, C.NOTHING);
@@ -825,7 +823,7 @@ Player.prototype._postInit = function() {
  * @param {Number} val `C.M_*` constant
  */
 Player.prototype.mode = function(val) {
-    if (!is.defined(val)) { throw new PlayerError("Please define a mode to set"); }
+    if (!is.defined(val)) { errors.player("Please define a mode to set"); }
     this.infiniteDuration = (val & C.M_INFINITE_DURATION) || undefined;
     this.handleEvents = (val & C.M_HANDLE_EVENTS) || undefined;
     this.controlsEnabled = (val & C.M_CONTROLS_ENABLED) || undefined;
@@ -888,7 +886,7 @@ Player.prototype.forceRedraw = function() {
  * @param {Number} time
  */
 Player.prototype.drawAt = function(time) {
-    if (time === Player.NO_TIME) throw new PlayerError(Errors.P.PASSED_TIME_VALUE_IS_NO_TIME);
+    if (time === Player.NO_TIME) errors.player(ErrLoc.P.PASSED_TIME_VALUE_IS_NO_TIME);
     if ((this.state.happens === C.RES_LOADING) &&
         (this.loadingMode === C.LM_ONREQUEST)) { this._postpone('drawAt', arguments);
                                                    return; } // if player loads remote resources just now,
@@ -896,7 +894,7 @@ Player.prototype.drawAt = function(time) {
                                                              // will be called when all remote resources were
                                                              // finished loading
     if ((time < 0) || (time > this.anim.duration)) {
-        throw new PlayerError(utils.strf(Errors.P.PASSED_TIME_NOT_IN_RANGE, [time]));
+        errors.player(utils.strf(ErrLoc.P.PASSED_TIME_NOT_IN_RANGE, [time]));
     }
     var anim = this.anim,
         u_before = this.__userBeforeRender,
@@ -1104,7 +1102,7 @@ Player.__invalidate = function(player) {
  */
 // TODO: change to before/after for events?
 Player.prototype.beforeFrame = function(callback) {
-    if (this.state.happens === C.PLAYING) throw new PlayerError(Errors.P.BEFOREFRAME_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFOREFRAME_BEFORE_PLAY);
     this.__userBeforeFrame = callback;
 };
 
@@ -1118,7 +1116,7 @@ Player.prototype.beforeFrame = function(callback) {
  * @param {Boolean} callback.return
  */
 Player.prototype.afterFrame = function(callback) {
-    if (this.state.happens === C.PLAYING) throw new PlayerError(Errors.P.AFTERFRAME_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERFRAME_BEFORE_PLAY);
     this.__userAfterFrame = callback;
 };
 
@@ -1132,7 +1130,7 @@ Player.prototype.afterFrame = function(callback) {
  * @param {Canvas2DContext} callback.ctx
  */
 Player.prototype.beforeRender = function(callback) {
-    if (this.state.happens === C.PLAYING) throw new PlayerError(Errors.P.BEFORENDER_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFORENDER_BEFORE_PLAY);
     this.__userBeforeRender = callback;
 };
 
@@ -1146,7 +1144,7 @@ Player.prototype.beforeRender = function(callback) {
  * @param {Canvas2DContext} callback.ctx
  */
 Player.prototype.afterRender = function(callback) {
-    if (this.state.happens === C.PLAYING) throw new PlayerError(Errors.P.AFTERRENDER_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERRENDER_BEFORE_PLAY);
     this.__userAfterRender = callback;
 };
 
@@ -1310,7 +1308,7 @@ Player.prototype._drawLoadingSplash = function(text) {
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.fillStyle = '#006';
     ctx.font = '12px sans-serif';
-    ctx.fillText(text || Strings.LOADING, 20, 25);
+    ctx.fillText(text || StrLoc.LOADING, 20, 25);
     ctx.restore();
 };
 
@@ -1349,7 +1347,7 @@ Player.prototype._drawErrorSplash = function(e) {
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.fillStyle = '#006';
     ctx.font = '14px sans-serif';
-    ctx.fillText(Strings.ERROR +
+    ctx.fillText(StrLoc.ERROR +
                  (e ? ': ' + (e.message || (typeof Error))
                     : '') + '.', 20, 25);
     ctx.restore();
@@ -1494,11 +1492,11 @@ Player.prototype.__unsubscribeDynamicEvents = function(anim) {
 };
 
 Player.prototype._ensureHasState = function() {
-    if (!this.state) throw new PlayerError(Errors.P.NO_STATE);
+    if (!this.state) errors.player(ErrLoc.P.NO_STATE);
 };
 
 Player.prototype._ensureHasAnim = function() {
-    if (!this.anim) throw new PlayerError(Errors.P.NO_ANIMATION);
+    if (!this.anim) errors.player(ErrLoc.P.NO_ANIMATION);
 };
 
 Player.prototype.__beforeFrame = function(anim) {
@@ -1558,7 +1556,7 @@ Player.prototype.__onerror = function(err) {
 
       player.anim = null;
       // was here: /*if (player.state)*/ player.__unsafe_stop();
-  } catch(e) { throw new SystemError(utils.strf(Errors.S.ERROR_HANDLING_FAILED, [err.message || err])); }
+  } catch(e) { errors.player(utils.strf(ErrLoc.S.ERROR_HANDLING_FAILED, [err.message || err])); }
 
   try {
       if (player.state &&
@@ -1627,7 +1625,7 @@ Player.prototype.__makeSafe = function(methods) {
   var player = this;
   for (var i = 0, il = methods.length; i < il; i++) {
     var method = methods[i];
-    if (!player[method]) throw new SystemError(utils.strf(Errors.S.NO_METHOD_FOR_PLAYER, [method]));
+    if (!player[method]) errors.system(utils.strf(ErrLoc.S.NO_METHOD_FOR_PLAYER, [method]));
     player['__unsafe_'+method] = player[method];
     player[method] = player.__defSafe(player[method]);
   }

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -218,8 +218,8 @@ Player.EMPTY_STROKE_WIDTH = 3;
 Player.prototype.init = function(elm, opts) {
     var me = this;
     this.on(C.S_ERROR, me.__onerror());
-    if (this.canvas || this.wrapper) errors.player(ErrLoc.P.INIT_TWICE);
-    if (this.anim) errors.player(ErrLoc.P.INIT_AFTER_LOAD);
+    if (this.canvas || this.wrapper) errors.player(ErrLoc.P.INIT_TWICE, this);
+    if (this.anim) errors.player(ErrLoc.P.INIT_AFTER_LOAD, this);
     this._initHandlers(); /* TODO: make automatic */
     this._prepare(elm);
     this._addOpts(Player.DEFAULT_CONFIGURATION);
@@ -268,7 +268,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
 
     if ((state.happens === C.PLAYING) ||
         (state.happens === C.PAUSED)) {
-        errors.player(ErrLoc.P.COULD_NOT_LOAD_WHILE_PLAYING);
+        errors.player(ErrLoc.P.COULD_NOT_LOAD_WHILE_PLAYING, player);
     }
 
     /* object */
@@ -295,7 +295,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
     //        we can't let ourselves create an importer instance manually here,
     //        so it's considered a problem of naming.
     if ((arg2 && arg2.IMPORTER_ID) || (arg3 && arg3.IMPORTER_ID)) {
-        errors.player(ErrLoc.P.IMPORTER_CONSTRUCTOR_PASSED);
+        errors.player(ErrLoc.P.IMPORTER_CONSTRUCTOR_PASSED, player);
     }
 
     if (is.fun(arg2)) { callback = arg2; } /* object, callback */
@@ -319,7 +319,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                              // it was requested after the call to 'play', or else it was called by user
                              // FIXME: may be playLock was set by player and user calls this method
                              //        while some animation is already loading
-        if (player._postponedLoad) errors.player(ErrLoc.P.LOAD_WAS_ALREADY_POSTPONED);
+        if (player._postponedLoad) errors.player(ErrLoc.P.LOAD_WAS_ALREADY_POSTPONED, player);
         player._lastReceivedAnimationId = null;
         // this kind of postponed call is different from the ones below (_clearPostpones and _postpone),
         // since this one is related to loading mode, rather than calling later some methods which
@@ -336,10 +336,10 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
         player.anim = null;
         player._reset();
         player.stop();
-        errors.player(ErrLoc.P.NO_ANIMATION_PASSED);
+        errors.player(ErrLoc.P.NO_ANIMATION_PASSED, player);
     }
 
-    if (!player.__canvasPrepared) errors.player(ErrLoc.P.CANVAS_NOT_PREPARED);
+    if (!player.__canvasPrepared) errors.player(ErrLoc.P.CANVAS_NOT_PREPARED, player);
 
     player._reset();
 
@@ -372,7 +372,7 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
             // subscribe to wait until remote resources will be ready or failed
             resourceManager.subscribe(player.id, remotes, [
                 function(res_results, err_count) {
-                    //if (err_count) errors.animation(ErrLoc.A.RESOURCES_FAILED_TO_LOAD);
+                    //if (err_count) errors.animation(ErrLoc.A.RESOURCES_FAILED_TO_LOAD, player);
                     if (player.anim === result) { // avoid race condition when there were two requests
                         // to load different animations and first one finished loading
                         // after the second one
@@ -465,7 +465,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
 
     if (state.happens === C.PLAYING) {
         if (player.infiniteDuration) return; // it's ok to skip this call if it's some dynamic animation (FIXME?)
-        else errors.player(ErrLoc.P.ALREADY_PLAYING);
+        else errors.player(ErrLoc.P.ALREADY_PLAYING, player);
     }
 
     if ((player.loadingMode === C.LM_ONPLAY) && !player._lastReceivedAnimationId) {
@@ -475,7 +475,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
         player._playLock = true;
         var loadArgs = player._postponedLoad,
             playArgs = arguments;
-        if (!loadArgs) errors.player(ErrLoc.P.NO_LOAD_CALL_BEFORE_PLAY);
+        if (!loadArgs) errors.player(ErrLoc.P.NO_LOAD_CALL_BEFORE_PLAY, player);
         var loadCallback = loadArgs[3];
         var afterLoad = function() {
             if (loadCallback) loadCallback.call(player, arguments);
@@ -516,7 +516,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
                      : (anim.duration || (anim.isEmpty() ? 0
                                                            : Animation.DEFAULT_DURATION));
 
-    if (state.duration === undefined) errors.player(ErrLoc.P.DURATION_IS_NOT_KNOWN);
+    if (state.duration === undefined) errors.player(ErrLoc.P.DURATION_IS_NOT_KNOWN, player);
 
     state.__startTime = Date.now();
     state.__redraws = 0;
@@ -636,7 +636,7 @@ Player.prototype.pause = function() {
 
     var state = player.state;
     if (state.happens === C.STOPPED) {
-        errors.player(ErrLoc.P.PAUSING_WHEN_STOPPED);
+        errors.player(ErrLoc.P.PAUSING_WHEN_STOPPED, player);
     }
 
     if (state.happens === C.PLAYING) {
@@ -682,12 +682,12 @@ provideEvents(Player, [ C.S_IMPORT, C.S_CHANGE_STATE, C.S_LOAD, C.S_RES_LOAD,
                         C.S_PLAY, C.S_PAUSE, C.S_STOP, C.S_COMPLETE, C.S_REPEAT,
                         C.S_ERROR ]);
 Player.prototype._prepare = function(elm) {
-    if (!elm) errors.player(ErrLoc.P.NO_WRAPPER_PASSED);
+    if (!elm) errors.player(ErrLoc.P.NO_WRAPPER_PASSED, this);
     var wrapper_id, wrapper;
     if (is.str(elm)) {
         wrapper_id = elm;
         wrapper = engine.getElementById(wrapper_id);
-        if (!wrapper_id) errors.player(utils.strf(ErrLoc.P.NO_WRAPPER_WITH_ID, [wrapper_id]));
+        if (!wrapper_id) errors.player(utils.strf(ErrLoc.P.NO_WRAPPER_WITH_ID, [wrapper_id]), this);
     } else {
         if (!elm.id) elm.id = ('anm-player-' + Player.__instances);
         wrapper_id = elm.id;
@@ -697,7 +697,7 @@ Player.prototype._prepare = function(elm) {
     this.id = assign_data.id;
     this.wrapper = assign_data.wrapper;
     this.canvas = assign_data.canvas;
-    if (!engine.checkPlayerCanvas(this.canvas)) errors.player(ErrLoc.P.CANVAS_NOT_VERIFIED);
+    if (!engine.checkPlayerCanvas(this.canvas)) errors.player(ErrLoc.P.CANVAS_NOT_VERIFIED, this);
     this.ctx = engine.getContext(this.canvas, '2d');
     this.state = Player.createState(this);
     this.fire(C.S_CHANGE_STATE, C.NOTHING);
@@ -814,7 +814,7 @@ Player.prototype._postInit = function() {
  * @param {Number} val `C.M_*` constant
  */
 Player.prototype.mode = function(val) {
-    if (!is.defined(val)) { errors.player("Please define a mode to set"); }
+    if (!is.defined(val)) { errors.player("Please define a mode to set", this); }
     this.infiniteDuration = (val & C.M_INFINITE_DURATION) || undefined;
     this.handleEvents = (val & C.M_HANDLE_EVENTS) || undefined;
     this.controlsEnabled = (val & C.M_CONTROLS_ENABLED) || undefined;
@@ -877,7 +877,7 @@ Player.prototype.forceRedraw = function() {
  * @param {Number} time
  */
 Player.prototype.drawAt = function(time) {
-    if (time === Player.NO_TIME) errors.player(ErrLoc.P.PASSED_TIME_VALUE_IS_NO_TIME);
+    if (time === Player.NO_TIME) errors.player(ErrLoc.P.PASSED_TIME_VALUE_IS_NO_TIME, this);
     if ((this.state.happens === C.RES_LOADING) &&
         (this.loadingMode === C.LM_ONREQUEST)) { this._postpone('drawAt', arguments);
                                                    return; } // if player loads remote resources just now,
@@ -885,7 +885,7 @@ Player.prototype.drawAt = function(time) {
                                                              // will be called when all remote resources were
                                                              // finished loading
     if ((time < 0) || (time > this.anim.duration)) {
-        errors.player(utils.strf(ErrLoc.P.PASSED_TIME_NOT_IN_RANGE, [time]));
+        errors.player(utils.strf(ErrLoc.P.PASSED_TIME_NOT_IN_RANGE, [time]), this);
     }
     var anim = this.anim,
         u_before = this.__userBeforeRender,
@@ -1093,7 +1093,7 @@ Player.__invalidate = function(player) {
  */
 // TODO: change to before/after for events?
 Player.prototype.beforeFrame = function(callback) {
-    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFOREFRAME_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFOREFRAME_BEFORE_PLAY, this);
     this.__userBeforeFrame = callback;
 };
 
@@ -1107,7 +1107,7 @@ Player.prototype.beforeFrame = function(callback) {
  * @param {Boolean} callback.return
  */
 Player.prototype.afterFrame = function(callback) {
-    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERFRAME_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERFRAME_BEFORE_PLAY, this);
     this.__userAfterFrame = callback;
 };
 
@@ -1121,7 +1121,7 @@ Player.prototype.afterFrame = function(callback) {
  * @param {Canvas2DContext} callback.ctx
  */
 Player.prototype.beforeRender = function(callback) {
-    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFORENDER_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.BEFORENDER_BEFORE_PLAY, this);
     this.__userBeforeRender = callback;
 };
 
@@ -1135,7 +1135,7 @@ Player.prototype.beforeRender = function(callback) {
  * @param {Canvas2DContext} callback.ctx
  */
 Player.prototype.afterRender = function(callback) {
-    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERRENDER_BEFORE_PLAY);
+    if (this.state.happens === C.PLAYING) errors.player(ErrLoc.P.AFTERRENDER_BEFORE_PLAY, this);
     this.__userAfterRender = callback;
 };
 
@@ -1484,11 +1484,11 @@ Player.prototype.__unsubscribeDynamicEvents = function(anim) {
 };
 
 Player.prototype._ensureHasState = function() {
-    if (!this.state) errors.player(ErrLoc.P.NO_STATE);
+    if (!this.state) errors.player(ErrLoc.P.NO_STATE, this);
 };
 
 Player.prototype._ensureHasAnim = function() {
-    if (!this.anim) errors.player(ErrLoc.P.NO_ANIMATION);
+    if (!this.anim) errors.player(ErrLoc.P.NO_ANIMATION, this);
 };
 
 Player.prototype.__beforeFrame = function(anim) {
@@ -1549,11 +1549,10 @@ Player.prototype.__onerror_f = function(err) {
       if (player.state) player.state.happens = C.ERROR;
       player.__lastError = err;
       player.fire(C.S_CHANGE_STATE, C.ERROR);
-      player.fire(C.S_ERROR, err);
 
       player.anim = null;
       // was here: /*if (player.state)*/ player.__unsafe_stop();
-  } catch(e) { errors.player(utils.strf(ErrLoc.S.ERROR_HANDLING_FAILED, [err.message || err])); }
+  } catch(e) { throw e; }
 
   try {
       if (player.state &&

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -514,7 +514,7 @@ Player.prototype.play = function(from, speed, stopAfter) {
                      : (anim.duration || (anim.isEmpty() ? 0
                                                            : Animation.DEFAULT_DURATION));
 
-    if (state.duration === undefined) ErrLoc. new PlayerError(ErrLoc.P.DURATION_IS_NOT_KNOWN);
+    if (state.duration === undefined) errors.player(ErrLoc.P.DURATION_IS_NOT_KNOWN);
 
     state.__startTime = Date.now();
     state.__redraws = 0;

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -216,6 +216,8 @@ Player.EMPTY_STROKE_WIDTH = 3;
  */
 
 Player.prototype.init = function(elm, opts) {
+    var me = this;
+    this.on(C.S_ERROR, me.__onerror());
     if (this.canvas || this.wrapper) errors.player(ErrLoc.P.INIT_TWICE);
     if (this.anim) errors.player(ErrLoc.P.INIT_AFTER_LOAD);
     this._initHandlers(); /* TODO: make automatic */
@@ -1456,6 +1458,7 @@ Player.prototype.__subscribeDynamicEvents = function(anim) {
         }
         if (!subscribed) {
             this.__boundTo.push([ anim.id, this.canvas ]);
+            anim.on(C.X_ERROR, this.__onerror());
             anim.subscribeEvents(this.canvas);
         }
     }
@@ -1529,10 +1532,15 @@ Player.prototype.__afterFrame = function(anim) {
     })(this, this.state, anim, this.__userAfterFrame);
 };
 
+Player.prototype.__onerror = function() {
+    var me = this;
+    return function(err) { return me.onerror_f(err); };
+}
+
 // Called when any error happens during player initialization or animation
 // Player should mute all non-system errors by default, and if it got a system error, it may show
 // this error in its UI
-Player.prototype.__onerror = function(err) {
+Player.prototype.__onerror_f = function(err) {
   var player = this;
   var doMute = player.muteErrors;
       doMute = doMute && !(err instanceof SystemError);
@@ -1561,11 +1569,6 @@ Player.prototype.__onerror = function(err) {
       try { this._drawErrorSplash(err); } catch(e) { /* skip errors in splash */ }
       throw err;
   }
-};
-
-Player.prototype.handle__x = function(type, evt) {
-    if (this.anim) this.anim.fire(type, this);
-    return true;
 };
 
 Player.prototype._clearPostpones = function() {

--- a/src/anm/render.js
+++ b/src/anm/render.js
@@ -79,26 +79,24 @@ function r_at(time, dt, ctx, anim, width, height, zoom, rib_color, before, after
     var size_differs = (width  != anim.width) ||
                        (height != anim.height);
     if (!size_differs) {
-        try {
-            ctx.clearRect(0, 0, anim.width,
-                                anim.height);
-            if (before) before(time, ctx);
-            if (zoom != 1) ctx.scale(zoom, zoom);
-            anim.render(ctx, time, dt);
-            if (after) after(time, ctx);
-        } finally { ctx.restore(); }
+        ctx.clearRect(0, 0, anim.width,
+                            anim.height);
+        if (before) before(time, ctx);
+        if (zoom != 1) ctx.scale(zoom, zoom);
+        anim.render(ctx, time, dt);
+        if (after) after(time, ctx);
+        ctx.restore();
     } else {
         r_with_ribbons(ctx, width, height,
                             anim.width, anim.height,
                             rib_color,
             function(_scale) {
-                try {
-                  ctx.clearRect(0, 0, anim.width, anim.height);
-                  if (before) before(time, ctx);
-                  if (zoom != 1) ctx.scale(zoom, zoom);
-                  anim.render(ctx, time, dt);
-                  if (after) after(time, ctx);
-                } finally { ctx.restore(); }
+                ctx.clearRect(0, 0, anim.width, anim.height);
+                if (before) before(time, ctx);
+                if (zoom != 1) ctx.scale(zoom, zoom);
+                anim.render(ctx, time, dt);
+                if (after) after(time, ctx);
+                ctx.restore();
             });
     }
 }

--- a/src/anm/resource_manager.js
+++ b/src/anm/resource_manager.js
@@ -69,9 +69,9 @@ function ResourceManager() {
 }
 
 ResourceManager.prototype.subscribe = function(subject_id, urls, callbacks, onprogress) {
-    if (!subject_id) errors.system('Subject ID is empty');
-    if (this._subscriptions[subject_id]) errors.system('This subject (\'' + subject_id + '\') is already subscribed to ' +
-                                                       'a bunch of resources, please group them in one.');
+    if (!subject_id) throw errors.system('Subject ID is empty');
+    if (this._subscriptions[subject_id]) throw errors.system('This subject (\'' + subject_id + '\') is already subscribed to ' +
+                                                             'a bunch of resources, please group them in one.');
 
     var filteredUrls = [];
     rmLog('subscribing ' + callbacks.length + ' to ' + urls.length + ' urls: ' + urls);
@@ -116,8 +116,8 @@ ResourceManager.prototype.subscribe = function(subject_id, urls, callbacks, onpr
 
 ResourceManager.prototype.loadOrGet = function(subject_id, url, loader, onComplete, onError) {
     var me = this;
-    if (!subject_id) errors.system('Subject ID is empty');
-    if (!url) errors.system('Given URL is empty');
+    if (!subject_id) throw errors.system('Subject ID is empty');
+    if (!url) throw errors.system('Given URL is empty');
     var progress_f = me._onprogress[subject_id];
     rmLog('request to load ' + url);
     if (me._cache[url]) {
@@ -236,7 +236,7 @@ ResourceManager.prototype.check = function() {
 };
 
 ResourceManager.prototype.cancel = function(subject_id) {
-    if (!subject_id) errors.system('Subject ID is empty');
+    if (!subject_id) throw errors.system('Subject ID is empty');
     if (this._waiting[subject_id]) {
         var urls = this._subscriptions[subject_id][0];
         if (urls) { for (var u = 0, ul = urls.length; u < ul; u++) {

--- a/src/anm/resource_manager.js
+++ b/src/anm/resource_manager.js
@@ -48,6 +48,8 @@ var conf = require('./conf.js'),
     log = require('./log.js'),
     is = require('./utils.js').is;
 
+var errors = require('./errors.js');
+
 function rmLog(str) {
   if (conf.logResMan) {
     log.debug(str);
@@ -67,9 +69,9 @@ function ResourceManager() {
 }
 
 ResourceManager.prototype.subscribe = function(subject_id, urls, callbacks, onprogress) {
-    if (!subject_id) throw new Error('Subject ID is empty');
-    if (this._subscriptions[subject_id]) throw new Error('This subject (\'' + subject_id + '\') is already subscribed to ' +
-                                                         'a bunch of resources, please group them in one.');
+    if (!subject_id) errors.system('Subject ID is empty');
+    if (this._subscriptions[subject_id]) errors.system('This subject (\'' + subject_id + '\') is already subscribed to ' +
+                                                       'a bunch of resources, please group them in one.');
 
     var filteredUrls = [];
     rmLog('subscribing ' + callbacks.length + ' to ' + urls.length + ' urls: ' + urls);
@@ -114,8 +116,8 @@ ResourceManager.prototype.subscribe = function(subject_id, urls, callbacks, onpr
 
 ResourceManager.prototype.loadOrGet = function(subject_id, url, loader, onComplete, onError) {
     var me = this;
-    if (!subject_id) throw new Error('Subject ID is empty');
-    if (!url) throw new Error('Given URL is empty');
+    if (!subject_id) errors.system('Subject ID is empty');
+    if (!url) errors.system('Given URL is empty');
     var progress_f = me._onprogress[subject_id];
     rmLog('request to load ' + url);
     if (me._cache[url]) {
@@ -234,7 +236,7 @@ ResourceManager.prototype.check = function() {
 };
 
 ResourceManager.prototype.cancel = function(subject_id) {
-    if (!subject_id) throw new Error('Subject ID is empty');
+    if (!subject_id) errors.system('Subject ID is empty');
     if (this._waiting[subject_id]) {
         var urls = this._subscriptions[subject_id][0];
         if (urls) { for (var u = 0, ul = urls.length; u < ul; u++) {

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -43,7 +43,6 @@ var theme = Controls.DEFAULT_THEME = require('./controls_theme.json');
 Controls.THEME = Controls.DEFAULT_THEME;
 
 Controls.LAST_ID = 0;
-provideEvents(Controls, [C.X_DRAW]);
 Controls.prototype.update = function(parent) {
     var cvs = this.canvas;
     if (!cvs) {
@@ -203,7 +202,6 @@ Controls.prototype.render = function(gtime) {
     }
 
     ctx.restore();
-    this.fire(C.X_DRAW);
 
     if (this.info) {
         if (s !== C.NOTHING) { this._infoShown = true; this.info.render(); }

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -1,10 +1,11 @@
-var provideEvents = require('../events.js').provideEvents,
-    C = require('../constants.js'),
-    engine = require('engine'),
-    InfoBlock = require('./infoblock.js'),
-    Strings = require('../loc.js').Strings,
-    utils = require('../utils.js'),
+var utils = require('../utils.js'),
     is = utils.is;
+
+var C = require('../constants.js'),
+    Strings = require('../loc.js').Strings;
+
+var engine = require('engine'),
+    InfoBlock = require('./infoblock.js');
 
 //fade modes
 var FADE_NONE = 0,
@@ -24,7 +25,7 @@ function Controls(player) {
     this.bounds = [];
     this.theme = null;
     this.info = null;
-    this._initHandlers(); /* TODO: make automatic */
+
     this.state = {
         happens: C.NOTHING,
         mpos: {x: 0, y: 0},

--- a/src/anm/ui/controls.js
+++ b/src/anm/ui/controls.js
@@ -64,7 +64,6 @@ Controls.prototype.update = function(parent) {
     }
     this.handleAreaChange();
     if (this.info) this.info.update(parent);
-    BACK_GRAD = null; // invalidate back gradient
 };
 
 Controls.prototype.subscribeEvents = function() {

--- a/src/anm/utils.js
+++ b/src/anm/utils.js
@@ -196,7 +196,7 @@ function strf(str, subst) {
 function collect_to(str, start, ch) {
     var result = '';
     for (var i = start; str[i] !== ch; i++) {
-        if (i === str.length) throw new SystemError('Reached end of string');
+        if (i === str.length) throw new Error('Reached end of string');
         result += str[i];
     }
     return result;

--- a/src/engine/dom-engine.js
+++ b/src/engine/dom-engine.js
@@ -141,7 +141,7 @@ $DE.ajax = function(url, callback, errback, method, headers) {
     }
 
     if (!req) {
-      throw new Error('Failed to create XMLHttp instance'); // SysErr
+        throw new Error('Failed to create XMLHttp instance'); // SysErr
     }
 
     var whenDone = function() {

--- a/src/module/shapes.js
+++ b/src/module/shapes.js
@@ -69,9 +69,5 @@ E.prototype.triangle = function(x, y, width, height) {
     path.add(new LSeg([ x + width, y + height ]));
     path.add(new LSeg([ x, y + height ]));
     path.add(new LSeg([ x + rx, y ]));
-    //path.add(new MSeg([ x - rx, ry ]));
-    //path.add(new LSeg([ x, -ry ]));
-    //path.add(new LSeg([ rx, ry ]));
-    //path.add(new LSeg([ x - rx, ry ]));
     return this.path(path);
 }


### PR DESCRIPTION
Several optimizations suggested by Chrome Profiler when tested with large numbers of objects, should highly improve performance:

* `try/catch` blocks were removed from render loop, the error system is based on events and passing the error to the subject before firing it now.
* excessive events like `X_DRAW` were removed, ability to handle `Player` events was removed from `Element` and `Animation` code, now only a subject of event may catch it's event, to avoid loops going too deep with no reason (keyboard/mouse events will still be passed to element's children if they were in bounds of element); the latter could cause errors with an audio/video, they rely on some Player events like `S_START`/`S_STOP`, so it _could be dangerous_;
* Excessive "safe" methods were removed because they used `try`/`catch` to handle errors;

Please **do not merge** until it will be safe to deploy.