### PR TITLE
Improvements for Animation/Element.find and Animation/Element.findAll

### DIFF
--- a/spec/Runner.html
+++ b/spec/Runner.html
@@ -16,7 +16,7 @@
   <script src="../src/module/animatron-importer.js"></script>
 
   <!-- include spec files here... -->
-  <script src="./check.spec.js"></script>
+  <script src="./search.spec.js"></script>
 
 </head>
 

--- a/spec/check.spec.js
+++ b/spec/check.spec.js
@@ -1,7 +1,0 @@
-describe('test', function() {
-
-    it('works', function() {
-        expect(true).toBeTruthy();
-    });
-
-});

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -1,3 +1,8 @@
+if (typeof anm === 'undefined') {
+    // running from a server
+    require('../dist/player.js');
+}
+
 describe('search', function() {
 
     var element = anm.Element._$;

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -94,7 +94,7 @@ describe('search', function() {
         expect(animation.findAll('foobar')[1].id).toEqual(searchForTwo.id);
 
         expect(rootElement.findAll('foobar')[0].id).toEqual(searchForOne.id);
-        expect(rootElement.findAll('foobar')[1].id).toEqual(searchForTwo.id);
+        expect(rootElement.findAll('foobar')[1]).not.toBeDefined();
     });
 
     describe('properly searches for an element by path, when', function() {
@@ -184,6 +184,7 @@ describe('search', function() {
 
         expect(rootElement.findAll('/sub-root/foobar')[0].id).toEqual(searchForOne.id);
         expect(rootElement.findAll('/sub-root/foobar')[1].id).toEqual(searchForTwo.id);
+        expect(rootElement.findAll('/sub-root/foobar')[2]).not.toBeDefined();
     });
 
     it('properly searches for an element or several elements by path, constructed using indexes', function() {
@@ -208,23 +209,23 @@ describe('search', function() {
         subRootElement.add(searchForTwo); // so it has index of 4 inside sub-root element
         subRootElement.add(element('index-5'));
 
-        expect(animation.find('/:0').id).toBeEqual(stubElement.id);
-        expect(animation.findAll('/:0')[0].id).toBeEqual(stubElement.id);
+        expect(animation.find('/:0').id).toEqual(stubElement.id);
+        expect(animation.findAll('/:0')[0].id).toEqual(stubElement.id);
 
-        expect(animation.find('/:1').id).toBeEqual(rootElement.id);
-        expect(animation.findAll('/:1')[0].id).toBeEqual(rootElement.id);
+        expect(animation.find('/:1').id).toEqual(rootElement.id);
+        expect(animation.findAll('/:1')[0].id).toEqual(rootElement.id);
 
         expect(animation.find('/:0/sub-root/foobar')).toBeNull();
         expect(animation.findAll('/:0/sub-root/foobar')).toBeEmpty();
 
-        expect(animation.find('/root/:1').name).toBeEqual('index-1');
-        expect(animation.findAll('/root/:1')[0].name).toBeEqual('index-1');
+        expect(animation.find('/root/:1').name).toEqual('index-1');
+        expect(animation.findAll('/root/:1')[0].name).toEqual('index-1');
 
-        expect(animation.find('/root/:3').name).toBeEqual('index-3');
-        expect(animation.findAll('/root/:3')[0].name).toBeEqual('index-3');
+        expect(animation.find('/root/:3').name).toEqual('index-3');
+        expect(animation.findAll('/root/:3')[0].name).toEqual('index-3');
 
-        expect(animation.find('/root/sub-root/:5').name).toBeEqual('index-5');
-        expect(animation.findAll('/root/sub-root/:5')[0].name).toBeEqual('index-5');
+        expect(animation.find('/root/sub-root/:5').name).toEqual('index-5');
+        expect(animation.findAll('/root/sub-root/:5')[0].name).toEqual('index-5');
 
         expect(animation.find('/:0/:5')).toBeNull();
         expect(animation.findAll('/:0/:5')).toBeEmpty();
@@ -232,55 +233,55 @@ describe('search', function() {
         expect(animation.find('/:0/:2/:5')).toBeNull();
         expect(animation.findAll('/:0/:2/:5')).toBeEmpty();
 
-        expect(animation.find('/:1/:2/:5').name).toBeEqual('index-5');
-        expect(animation.findAll('/:1/:2/:5')[0].name).toBeEqual('index-5');
+        expect(animation.find('/:1/:2/:5').name).toEqual('index-5');
+        expect(animation.findAll('/:1/:2/:5')[0].name).toEqual('index-5');
 
-        expect(subRootElement.name).toBeEqual('sub-root');
-        expect(animation.find('/root/:2').name).toBeEqual(subRootElement.name);
-        expect(animation.findAll('/root/:2')[0].name).toBeEqual(subRootElement.name);
+        expect(subRootElement.name).toEqual('sub-root');
+        expect(animation.find('/root/:2').name).toEqual(subRootElement.name);
+        expect(animation.findAll('/root/:2')[0].name).toEqual(subRootElement.name);
 
-        expect(animation.find('/root/sub-root/:1').id).toBeEqual(searchForOne.id);
-        expect(animation.find('/root/sub-root/:1').name).toBeEqual('foobar');
-        expect(animation.findAll('/root/sub-root/:1')[0].id).toBeEqual(searchForOne.id);
-        expect(animation.findAll('/root/sub-root/:1')[0].name).toBeEqual('foobar');
+        expect(animation.find('/root/sub-root/:1').id).toEqual(searchForOne.id);
+        expect(animation.find('/root/sub-root/:1').name).toEqual('foobar');
+        expect(animation.findAll('/root/sub-root/:1')[0].id).toEqual(searchForOne.id);
+        expect(animation.findAll('/root/sub-root/:1')[0].name).toEqual('foobar');
 
-        expect(animation.find('/root/sub-root/:4').id).toBeEqual(searchForTwo.id);
-        expect(animation.find('/root/sub-root/:4').name).toBeEqual('foobar');
-        expect(animation.findAll('/root/sub-root/:4')[0].id).toBeEqual(searchForTwo.id);
-        expect(animation.findAll('/root/sub-root/:4')[0].name).toBeEqual('foobar');
+        expect(animation.find('/root/sub-root/:4').id).toEqual(searchForTwo.id);
+        expect(animation.find('/root/sub-root/:4').name).toEqual('foobar');
+        expect(animation.findAll('/root/sub-root/:4')[0].id).toEqual(searchForTwo.id);
+        expect(animation.findAll('/root/sub-root/:4')[0].name).toEqual('foobar');
 
-        expect(animation.find('/:1/sub-root/:1').id).toBeEqual(searchForOne.id);
-        expect(animation.find('/:1/sub-root/:1').name).toBeEqual('foobar');
-        expect(animation.findAll('/:1/sub-root/:1')[0].id).toBeEqual(searchForOne.id);
-        expect(animation.findAll('/:1/sub-root/:1')[0].name).toBeEqual('foobar');
+        expect(animation.find('/:1/sub-root/:1').id).toEqual(searchForOne.id);
+        expect(animation.find('/:1/sub-root/:1').name).toEqual('foobar');
+        expect(animation.findAll('/:1/sub-root/:1')[0].id).toEqual(searchForOne.id);
+        expect(animation.findAll('/:1/sub-root/:1')[0].name).toEqual('foobar');
 
-        expect(animation.find('/:1/sub-root/:4').id).toBeEqual(searchForTwo.id);
-        expect(animation.find('/:1/sub-root/:4').name).toBeEqual('foobar');
-        expect(animation.findAll('/:1/sub-root/:4')[0].id).toBeEqual(searchForTwo.id);
-        expect(animation.findAll('/:1/sub-root/:4')[0].name).toBeEqual('foobar');
+        expect(animation.find('/:1/sub-root/:4').id).toEqual(searchForTwo.id);
+        expect(animation.find('/:1/sub-root/:4').name).toEqual('foobar');
+        expect(animation.findAll('/:1/sub-root/:4')[0].id).toEqual(searchForTwo.id);
+        expect(animation.findAll('/:1/sub-root/:4')[0].name).toEqual('foobar');
 
-        expect(animation.find('/:1/:2/:1').id).toBeEqual(searchForOne.id);
-        expect(animation.find('/:1/:2/:1').name).toBeEqual('foobar');
-        expect(animation.findAll('/:1/:2/:1')[0].id).toBeEqual(searchForOne.id);
-        expect(animation.findAll('/:1/:2/:1')[0].name).toBeEqual('foobar');
+        expect(animation.find('/:1/:2/:1').id).toEqual(searchForOne.id);
+        expect(animation.find('/:1/:2/:1').name).toEqual('foobar');
+        expect(animation.findAll('/:1/:2/:1')[0].id).toEqual(searchForOne.id);
+        expect(animation.findAll('/:1/:2/:1')[0].name).toEqual('foobar');
 
-        expect(animation.find('/:1/:2/:4').id).toBeEqual(searchForTwo.id);
-        expect(animation.find('/:1/:2/:4').name).toBeEqual('foobar');
-        expect(animation.findAll('/:1/:2/:4')[0].id).toBeEqual(searchForTwo.id);
-        expect(animation.findAll('/:1/:2/:4')[0].name).toBeEqual('foobar');
+        expect(animation.find('/:1/:2/:4').id).toEqual(searchForTwo.id);
+        expect(animation.find('/:1/:2/:4').name).toEqual('foobar');
+        expect(animation.findAll('/:1/:2/:4')[0].id).toEqual(searchForTwo.id);
+        expect(animation.findAll('/:1/:2/:4')[0].name).toEqual('foobar');
 
-        expect(rootElement.find('/:2/:1').id).toBeEqual(searchForOne.id);
-        expect(rootElement.find('/:2/:1').name).toBeEqual('foobar');
-        expect(rootElement.findAll('/:2/:1')[0].id).toBeEqual(searchForOne.id);
-        expect(rootElement.findAll('/:2/:1')[0].name).toBeEqual('foobar');
+        expect(rootElement.find('/:2/:1').id).toEqual(searchForOne.id);
+        expect(rootElement.find('/:2/:1').name).toEqual('foobar');
+        expect(rootElement.findAll('/:2/:1')[0].id).toEqual(searchForOne.id);
+        expect(rootElement.findAll('/:2/:1')[0].name).toEqual('foobar');
 
-        expect(rootElement.find('/:2/:4').id).toBeEqual(searchForTwo.id);
-        expect(rootElement.find('/:2/:4').name).toBeEqual('foobar');
-        expect(rootElement.findAll('/:2/:4')[0].id).toBeEqual(searchForTwo.id);
-        expect(rootElement.findAll('/:2/:4')[0].name).toBeEqual('foobar');
+        expect(rootElement.find('/:2/:4').id).toEqual(searchForTwo.id);
+        expect(rootElement.find('/:2/:4').name).toEqual('foobar');
+        expect(rootElement.findAll('/:2/:4')[0].id).toEqual(searchForTwo.id);
+        expect(rootElement.findAll('/:2/:4')[0].name).toEqual('foobar');
 
-        expect(subRootElement.find('/:5').name).toBeEqual('index-5');
-        expect(subRootElement.findAll('/:5')[0].name).toBeEqual('index-5');
+        expect(subRootElement.find('/:5').name).toEqual('index-5');
+        expect(subRootElement.findAll('/:5')[0].name).toEqual('index-5');
 
         expect(subRootElement.find('/:7')).toBeNull();
         expect(subRootElement.findAll('/:7')).toBeEmpty();

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -42,8 +42,8 @@ describe('search', function() {
             animation.add(element('stub'));
             animation.add(searchFor);
 
-            expect(animation.find('foobar').id).toEqual(searchFor.id);
-            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+            expect(animation.find('foobar')).toBe(searchFor);
+            expect(animation.findAll('foobar')[0]).toBe(searchFor);
         });
 
 
@@ -54,8 +54,8 @@ describe('search', function() {
             animation.add(element('stub'));
             animation.add(element('root').add(element('sub-root').add(searchFor)));
 
-            expect(animation.find('foobar').id).toEqual(searchFor.id);
-            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+            expect(animation.find('foobar')).toBe(searchFor);
+            expect(animation.findAll('foobar')[0]).toBe(searchFor);
         });
 
         it('placed as a child somewhere deep inside and search started from a containing element', function() {
@@ -71,11 +71,11 @@ describe('search', function() {
             expect(stubElement.find('foobar')).toBeNull();
             expect(stubElement.findAll('foobar')).toBeEmpty();
 
-            expect(rootElement.find('foobar').id).toEqual(searchFor.id);
-            expect(rootElement.findAll('foobar')[0].id).toEqual(searchFor.id);
+            expect(rootElement.find('foobar')).toBe(searchFor);
+            expect(rootElement.findAll('foobar')[0]).toBe(searchFor);
 
-            expect(subRootElement.find('foobar').id).toEqual(searchFor.id);
-            expect(subRootElement.findAll('foobar')[0].id).toEqual(searchFor.id);
+            expect(subRootElement.find('foobar')).toBe(searchFor);
+            expect(subRootElement.findAll('foobar')[0]).toBe(searchFor);
         });
 
     });
@@ -90,10 +90,10 @@ describe('search', function() {
         animation.add(rootElement.add(element('sub-root').add(searchForOne)));
         animation.add(element('another').add(searchForTwo));
 
-        expect(animation.findAll('foobar')[0].id).toEqual(searchForOne.id);
-        expect(animation.findAll('foobar')[1].id).toEqual(searchForTwo.id);
+        expect(animation.findAll('foobar')[0]).toBe(searchForOne);
+        expect(animation.findAll('foobar')[1]).toBe(searchForTwo);
 
-        expect(rootElement.findAll('foobar')[0].id).toEqual(searchForOne.id);
+        expect(rootElement.findAll('foobar')[0]).toBe(searchForOne);
         expect(rootElement.findAll('foobar')[1]).not.toBeDefined();
     });
 
@@ -105,8 +105,8 @@ describe('search', function() {
             animation.add(element('stub'));
             animation.add(searchFor);
 
-            expect(animation.find('/foobar').id).toEqual(searchFor.id);
-            expect(animation.findAll('/foobar')[0].id).toEqual(searchFor.id);
+            expect(animation.find('/foobar')).toBe(searchFor);
+            expect(animation.findAll('/foobar')[0]).toBe(searchFor);
         });
 
 
@@ -134,11 +134,11 @@ describe('search', function() {
             expect(animation.find('/root/sub-root/foobar').id).toEqual(searchFor.id);
             expect(animation.findAll('/root/sub-root/foobar')[0].id).toEqual(searchFor.id);
 
-            //expect(animation.find('/root/*/foobar').id).toEqual(searchFor.id);
-            //expect(animation.findAll('/root/*/foobar')[0].id).toEqual(searchFor.id);
+            //expect(animation.find('/root/*/foobar')).toBe(searchFor);
+            //expect(animation.findAll('/root/*/foobar')[0]).toBe(searchFor);
 
-            //expect(animation.find('/*/foobar').id).toEqual(searchFor.id);
-            //expect(animation.findAll('/*/foobar')[0].id).toEqual(searchFor.id);
+            //expect(animation.find('/*/foobar')).toBe(searchFor);
+            //expect(animation.findAll('/*/foobar')[0]).toBe(searchFor);
         });
 
         it('placed as a child somewhere deep inside and search started from a containing element', function() {
@@ -157,14 +157,14 @@ describe('search', function() {
             expect(rootElement.find('/root')).toBeNull();
             expect(rootElement.findAll('/root')).toBeEmpty();
 
-            expect(rootElement.find('/sub-root/foobar').id).toEqual(searchFor.id);
-            expect(rootElement.findAll('/sub-root/foobar')[0].id).toEqual(searchFor.id);
+            expect(rootElement.find('/sub-root/foobar')).toBe(searchFor);
+            expect(rootElement.findAll('/sub-root/foobar')[0]).toBe(searchFor);
 
-            //expect(rootElement.find('/*/foobar').id).toEqual(searchFor.id);
-            //expect(rootElement.findAll('/*/foobar')[0].id).toEqual(searchFor.id);
+            //expect(rootElement.find('/*/foobar')).toBe(searchFor);
+            //expect(rootElement.findAll('/*/foobar')[0]).toBe(searchFor);
 
-            expect(subRootElement.find('/foobar').id).toEqual(searchFor.id);
-            expect(subRootElement.findAll('/foobar')[0].id).toEqual(searchFor.id);
+            expect(subRootElement.find('/foobar')).toBe(searchFor);
+            expect(subRootElement.findAll('/foobar')[0]).toBe(searchFor);
         });
 
     });
@@ -179,11 +179,11 @@ describe('search', function() {
         animation.add(rootElement.add(element('sub-root').add(searchForOne).add(searchForTwo)));
         animation.add(element('another'));
 
-        expect(animation.findAll('/root/sub-root/foobar')[0].id).toEqual(searchForOne.id);
-        expect(animation.findAll('/root/sub-root/foobar')[1].id).toEqual(searchForTwo.id);
+        expect(animation.findAll('/root/sub-root/foobar')[0]).toBe(searchForOne);
+        expect(animation.findAll('/root/sub-root/foobar')[1]).toBe(searchForTwo);
 
-        expect(rootElement.findAll('/sub-root/foobar')[0].id).toEqual(searchForOne.id);
-        expect(rootElement.findAll('/sub-root/foobar')[1].id).toEqual(searchForTwo.id);
+        expect(rootElement.findAll('/sub-root/foobar')[0]).toBe(searchForOne);
+        expect(rootElement.findAll('/sub-root/foobar')[1]).toBe(searchForTwo);
         expect(rootElement.findAll('/sub-root/foobar')[2]).not.toBeDefined();
     });
 
@@ -209,11 +209,11 @@ describe('search', function() {
         subRootElement.add(searchForTwo); // so it has index of 4 inside sub-root element
         subRootElement.add(element('index-5'));
 
-        expect(animation.find('/:0').id).toEqual(stubElement.id);
-        expect(animation.findAll('/:0')[0].id).toEqual(stubElement.id);
+        expect(animation.find('/:0')).toBe(stubElement);
+        expect(animation.findAll('/:0')[0]).toBe(stubElement);
 
-        expect(animation.find('/:1').id).toEqual(rootElement.id);
-        expect(animation.findAll('/:1')[0].id).toEqual(rootElement.id);
+        expect(animation.find('/:1')).toBe(rootElement);
+        expect(animation.findAll('/:1')[0]).toBe(rootElement);
 
         expect(animation.find('/:0/sub-root/foobar')).toBeNull();
         expect(animation.findAll('/:0/sub-root/foobar')).toBeEmpty();
@@ -240,45 +240,29 @@ describe('search', function() {
         expect(animation.find('/root/:2').name).toEqual(subRootElement.name);
         expect(animation.findAll('/root/:2')[0].name).toEqual(subRootElement.name);
 
-        expect(animation.find('/root/sub-root/:1').id).toEqual(searchForOne.id);
-        expect(animation.find('/root/sub-root/:1').name).toEqual('foobar');
-        expect(animation.findAll('/root/sub-root/:1')[0].id).toEqual(searchForOne.id);
-        expect(animation.findAll('/root/sub-root/:1')[0].name).toEqual('foobar');
+        expect(animation.find('/root/sub-root/:1')).toBe(searchForOne);
+        expect(animation.findAll('/root/sub-root/:1')[0]).toBe(searchForOne);
 
-        expect(animation.find('/root/sub-root/:4').id).toEqual(searchForTwo.id);
-        expect(animation.find('/root/sub-root/:4').name).toEqual('foobar');
-        expect(animation.findAll('/root/sub-root/:4')[0].id).toEqual(searchForTwo.id);
-        expect(animation.findAll('/root/sub-root/:4')[0].name).toEqual('foobar');
+        expect(animation.find('/root/sub-root/:4')).toBe(searchForTwo);
+        expect(animation.findAll('/root/sub-root/:4')[0]).toBe(searchForTwo);
 
-        expect(animation.find('/:1/sub-root/:1').id).toEqual(searchForOne.id);
-        expect(animation.find('/:1/sub-root/:1').name).toEqual('foobar');
-        expect(animation.findAll('/:1/sub-root/:1')[0].id).toEqual(searchForOne.id);
-        expect(animation.findAll('/:1/sub-root/:1')[0].name).toEqual('foobar');
+        expect(animation.find('/:1/sub-root/:1')).toBe(searchForOne);
+        expect(animation.findAll('/:1/sub-root/:1')[0]).toBe(searchForOne);
 
-        expect(animation.find('/:1/sub-root/:4').id).toEqual(searchForTwo.id);
-        expect(animation.find('/:1/sub-root/:4').name).toEqual('foobar');
-        expect(animation.findAll('/:1/sub-root/:4')[0].id).toEqual(searchForTwo.id);
-        expect(animation.findAll('/:1/sub-root/:4')[0].name).toEqual('foobar');
+        expect(animation.find('/:1/sub-root/:4')).toBe(searchForTwo);
+        expect(animation.findAll('/:1/sub-root/:4')[0]).toBe(searchForTwo);
 
-        expect(animation.find('/:1/:2/:1').id).toEqual(searchForOne.id);
-        expect(animation.find('/:1/:2/:1').name).toEqual('foobar');
-        expect(animation.findAll('/:1/:2/:1')[0].id).toEqual(searchForOne.id);
-        expect(animation.findAll('/:1/:2/:1')[0].name).toEqual('foobar');
+        expect(animation.find('/:1/:2/:1')).toBe(searchForOne);
+        expect(animation.findAll('/:1/:2/:1')[0]).toBe(searchForOne);
 
-        expect(animation.find('/:1/:2/:4').id).toEqual(searchForTwo.id);
-        expect(animation.find('/:1/:2/:4').name).toEqual('foobar');
-        expect(animation.findAll('/:1/:2/:4')[0].id).toEqual(searchForTwo.id);
-        expect(animation.findAll('/:1/:2/:4')[0].name).toEqual('foobar');
+        expect(animation.find('/:1/:2/:4')).toBe(searchForTwo);
+        expect(animation.findAll('/:1/:2/:4')[0]).toBe(searchForTwo);
 
-        expect(rootElement.find('/:2/:1').id).toEqual(searchForOne.id);
-        expect(rootElement.find('/:2/:1').name).toEqual('foobar');
-        expect(rootElement.findAll('/:2/:1')[0].id).toEqual(searchForOne.id);
-        expect(rootElement.findAll('/:2/:1')[0].name).toEqual('foobar');
+        expect(rootElement.find('/:2/:1')).toBe(searchForOne);
+        expect(rootElement.findAll('/:2/:1')[0]).toBe(searchForOne);
 
-        expect(rootElement.find('/:2/:4').id).toEqual(searchForTwo.id);
-        expect(rootElement.find('/:2/:4').name).toEqual('foobar');
-        expect(rootElement.findAll('/:2/:4')[0].id).toEqual(searchForTwo.id);
-        expect(rootElement.findAll('/:2/:4')[0].name).toEqual('foobar');
+        expect(rootElement.find('/:2/:4')).toBe(searchForTwo);
+        expect(rootElement.findAll('/:2/:4')[0]).toBe(searchForTwo);
 
         expect(subRootElement.find('/:5').name).toEqual('index-5');
         expect(subRootElement.findAll('/:5')[0].name).toEqual('index-5');

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -27,6 +27,7 @@ describe('search', function() {
         var animation = new anm.Animation();
 
         animation.add(element('stub'));
+        animation.add(element().add(element()));
 
         expect(animation.find('foobar')).toBeNull();
         expect(animation.findAll('foobar')).toBeEmpty();
@@ -83,24 +84,29 @@ describe('search', function() {
         var animation = new anm.Animation();
         var searchForOne = element('foobar'),
             searchForTwo = element('foobar');
+        var rootElement = element('root');
+
         animation.add(element('stub'));
-        animation.add(element('root').add(element('sub-root').add(searchForOne)));
+        animation.add(rootElement.add(element('sub-root').add(searchForOne)));
         animation.add(element('another').add(searchForTwo));
 
         expect(animation.findAll('foobar')[0].id).toEqual(searchForOne.id);
         expect(animation.findAll('foobar')[1].id).toEqual(searchForTwo.id);
+
+        expect(rootElement.findAll('foobar')[0].id).toEqual(searchForOne.id);
+        expect(rootElement.findAll('foobar')[1].id).toEqual(searchForTwo.id);
     });
 
     describe('properly searches for an element by path, when', function() {
 
         it('placed in a root', function() {
             var animation = new anm.Animation();
-            var searchFor = element('Foobar');
+            var searchFor = element('foobar');
             animation.add(element('stub'));
             animation.add(searchFor);
 
-            expect(animation.find('/Foobar').id).toEqual(searchFor.id);
-            expect(animation.findAll('/Foobar')[0].id).toEqual(searchFor.id);
+            expect(animation.find('/foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('/foobar')[0].id).toEqual(searchFor.id);
         });
 
 
@@ -110,9 +116,175 @@ describe('search', function() {
             animation.add(element('stub'));
             animation.add(element('root').add(element('sub-root').add(searchFor)));
 
-            expect(animation.find('foobar').id).toEqual(searchFor.id);
-            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+            expect(animation.find('/foobar')).toBeNull();
+            expect(animation.findAll('/foobar')).toBeEmpty();
+
+            expect(animation.find('/stub/foobar')).toBeNull();
+            expect(animation.findAll('/stub/foobar')).toBeEmpty();
+
+            expect(animation.find('/stub/sub-root/foobar')).toBeNull();
+            expect(animation.findAll('/stub/sub-root/foobar')).toBeEmpty();
+
+            expect(animation.find('/stub/*/foobar')).toBeNull();
+            expect(animation.findAll('/stub/*/foobar')).toBeEmpty();
+
+            expect(animation.find('/root/foobar')).toBeNull();
+            expect(animation.findAll('/root/foobar')).toBeEmpty();
+
+            expect(animation.find('/root/sub-root/foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('/root/sub-root/foobar')[0].id).toEqual(searchFor.id);
+
+            //expect(animation.find('/root/*/foobar').id).toEqual(searchFor.id);
+            //expect(animation.findAll('/root/*/foobar')[0].id).toEqual(searchFor.id);
+
+            //expect(animation.find('/*/foobar').id).toEqual(searchFor.id);
+            //expect(animation.findAll('/*/foobar')[0].id).toEqual(searchFor.id);
         });
+
+        it('placed as a child somewhere deep inside and search started from a containing element', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('foobar');
+
+            var stubElement = element('stub');
+            animation.add(stubElement);
+            var rootElement = element('root'),
+                subRootElement = element('sub-root');
+            animation.add(rootElement.add(subRootElement.add(searchFor)));
+
+            expect(stubElement.find('/foobar')).toBeNull();
+            expect(stubElement.findAll('/foobar')).toBeEmpty();
+
+            expect(rootElement.find('/root')).toBeNull();
+            expect(rootElement.findAll('/root')).toBeEmpty();
+
+            expect(rootElement.find('/sub-root/foobar').id).toEqual(searchFor.id);
+            expect(rootElement.findAll('/sub-root/foobar')[0].id).toEqual(searchFor.id);
+
+            //expect(rootElement.find('/*/foobar').id).toEqual(searchFor.id);
+            //expect(rootElement.findAll('/*/foobar')[0].id).toEqual(searchFor.id);
+
+            expect(subRootElement.find('/foobar').id).toEqual(searchFor.id);
+            expect(subRootElement.findAll('/foobar')[0].id).toEqual(searchFor.id);
+        });
+
+    });
+
+    it('properly searches for multiple elements with a same name, placed in a same element, by path', function() {
+        var animation = new anm.Animation();
+        var searchForOne = element('foobar'),
+            searchForTwo = element('foobar');
+        var rootElement = element('root');
+
+        animation.add(element('stub'));
+        animation.add(rootElement.add(element('sub-root').add(searchForOne).add(searchForTwo)));
+        animation.add(element('another'));
+
+        expect(animation.findAll('/root/sub-root/foobar')[0].id).toEqual(searchForOne.id);
+        expect(animation.findAll('/root/sub-root/foobar')[1].id).toEqual(searchForTwo.id);
+
+        expect(rootElement.findAll('/sub-root/foobar')[0].id).toEqual(searchForOne.id);
+        expect(rootElement.findAll('/sub-root/foobar')[1].id).toEqual(searchForTwo.id);
+    });
+
+    it('properly searches for an element or several elements by path, constructed using indexes', function() {
+        var animation = new anm.Animation();
+        var searchForOne = element('foobar'),
+            searchForTwo = element('foobar');
+
+        var stubElement = element('stub');
+        var rootElement = element('root'),
+            subRootElement = element('sub-root');
+
+        animation.add(stubElement);
+        animation.add(rootElement);
+        rootElement.add(element('index-0'));
+        rootElement.add(element('index-1'));
+        rootElement.add(subRootElement); // so it has index of 2 inside root element
+        rootElement.add(element('index-3'));
+        subRootElement.add(element('index-0'));
+        subRootElement.add(searchForOne); // so it has index of 1 inside sub-root element
+        subRootElement.add(element('index-2'));
+        subRootElement.add(element('index-3'));
+        subRootElement.add(searchForTwo); // so it has index of 4 inside sub-root element
+        subRootElement.add(element('index-5'));
+
+        expect(animation.find('/:0').id).toBeEqual(stubElement.id);
+        expect(animation.findAll('/:0')[0].id).toBeEqual(stubElement.id);
+
+        expect(animation.find('/:1').id).toBeEqual(rootElement.id);
+        expect(animation.findAll('/:1')[0].id).toBeEqual(rootElement.id);
+
+        expect(animation.find('/:0/sub-root/foobar')).toBeNull();
+        expect(animation.findAll('/:0/sub-root/foobar')).toBeEmpty();
+
+        expect(animation.find('/root/:1').name).toBeEqual('index-1');
+        expect(animation.findAll('/root/:1')[0].name).toBeEqual('index-1');
+
+        expect(animation.find('/root/:3').name).toBeEqual('index-3');
+        expect(animation.findAll('/root/:3')[0].name).toBeEqual('index-3');
+
+        expect(animation.find('/root/sub-root/:5').name).toBeEqual('index-5');
+        expect(animation.findAll('/root/sub-root/:5')[0].name).toBeEqual('index-5');
+
+        expect(animation.find('/:0/:5')).toBeNull();
+        expect(animation.findAll('/:0/:5')).toBeEmpty();
+
+        expect(animation.find('/:0/:2/:5')).toBeNull();
+        expect(animation.findAll('/:0/:2/:5')).toBeEmpty();
+
+        expect(animation.find('/:1/:2/:5').name).toBeEqual('index-5');
+        expect(animation.findAll('/:1/:2/:5')[0].name).toBeEqual('index-5');
+
+        expect(subRootElement.name).toBeEqual('sub-root');
+        expect(animation.find('/root/:2').name).toBeEqual(subRootElement.name);
+        expect(animation.findAll('/root/:2')[0].name).toBeEqual(subRootElement.name);
+
+        expect(animation.find('/root/sub-root/:1').id).toBeEqual(searchForOne.id);
+        expect(animation.find('/root/sub-root/:1').name).toBeEqual('foobar');
+        expect(animation.findAll('/root/sub-root/:1')[0].id).toBeEqual(searchForOne.id);
+        expect(animation.findAll('/root/sub-root/:1')[0].name).toBeEqual('foobar');
+
+        expect(animation.find('/root/sub-root/:4').id).toBeEqual(searchForTwo.id);
+        expect(animation.find('/root/sub-root/:4').name).toBeEqual('foobar');
+        expect(animation.findAll('/root/sub-root/:4')[0].id).toBeEqual(searchForTwo.id);
+        expect(animation.findAll('/root/sub-root/:4')[0].name).toBeEqual('foobar');
+
+        expect(animation.find('/:1/sub-root/:1').id).toBeEqual(searchForOne.id);
+        expect(animation.find('/:1/sub-root/:1').name).toBeEqual('foobar');
+        expect(animation.findAll('/:1/sub-root/:1')[0].id).toBeEqual(searchForOne.id);
+        expect(animation.findAll('/:1/sub-root/:1')[0].name).toBeEqual('foobar');
+
+        expect(animation.find('/:1/sub-root/:4').id).toBeEqual(searchForTwo.id);
+        expect(animation.find('/:1/sub-root/:4').name).toBeEqual('foobar');
+        expect(animation.findAll('/:1/sub-root/:4')[0].id).toBeEqual(searchForTwo.id);
+        expect(animation.findAll('/:1/sub-root/:4')[0].name).toBeEqual('foobar');
+
+        expect(animation.find('/:1/:2/:1').id).toBeEqual(searchForOne.id);
+        expect(animation.find('/:1/:2/:1').name).toBeEqual('foobar');
+        expect(animation.findAll('/:1/:2/:1')[0].id).toBeEqual(searchForOne.id);
+        expect(animation.findAll('/:1/:2/:1')[0].name).toBeEqual('foobar');
+
+        expect(animation.find('/:1/:2/:4').id).toBeEqual(searchForTwo.id);
+        expect(animation.find('/:1/:2/:4').name).toBeEqual('foobar');
+        expect(animation.findAll('/:1/:2/:4')[0].id).toBeEqual(searchForTwo.id);
+        expect(animation.findAll('/:1/:2/:4')[0].name).toBeEqual('foobar');
+
+        expect(rootElement.find('/:2/:1').id).toBeEqual(searchForOne.id);
+        expect(rootElement.find('/:2/:1').name).toBeEqual('foobar');
+        expect(rootElement.findAll('/:2/:1')[0].id).toBeEqual(searchForOne.id);
+        expect(rootElement.findAll('/:2/:1')[0].name).toBeEqual('foobar');
+
+        expect(rootElement.find('/:2/:4').id).toBeEqual(searchForTwo.id);
+        expect(rootElement.find('/:2/:4').name).toBeEqual('foobar');
+        expect(rootElement.findAll('/:2/:4')[0].id).toBeEqual(searchForTwo.id);
+        expect(rootElement.findAll('/:2/:4')[0].name).toBeEqual('foobar');
+
+        expect(subRootElement.find('/:5').name).toBeEqual('index-5');
+        expect(subRootElement.findAll('/:5')[0].name).toBeEqual('index-5');
+
+        expect(subRootElement.find('/:7')).toBeNull();
+        expect(subRootElement.findAll('/:7')).toBeEmpty();
+
 
     });
 

--- a/spec/search.spec.js
+++ b/spec/search.spec.js
@@ -1,0 +1,119 @@
+describe('search', function() {
+
+    var element = anm.Element._$;
+
+    beforeEach(function() {
+        jasmine.addMatchers({
+            toBeEmpty: function() {
+                return {
+                    compare: function(actual, expected) {
+                        return {
+                            pass: (actual instanceof Array) && (actual.length === 0)
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it('finds nothing when animation is empty', function() {
+        var animation = new anm.Animation();
+
+        expect(animation.find('foobar')).toBeNull();
+        expect(animation.findAll('foobar')).toBeEmpty();
+    });
+
+    it('finds nothing when there\'s no such element in animation', function() {
+        var animation = new anm.Animation();
+
+        animation.add(element('stub'));
+
+        expect(animation.find('foobar')).toBeNull();
+        expect(animation.findAll('foobar')).toBeEmpty();
+    });
+
+    describe('properly searches for an element by name, when', function() {
+
+        it('placed in a root', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('foobar');
+
+            animation.add(element('stub'));
+            animation.add(searchFor);
+
+            expect(animation.find('foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+        });
+
+
+        it('placed as a child somewhere deep inside', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('foobar');
+
+            animation.add(element('stub'));
+            animation.add(element('root').add(element('sub-root').add(searchFor)));
+
+            expect(animation.find('foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+        });
+
+        it('placed as a child somewhere deep inside and search started from a containing element', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('foobar');
+
+            var stubElement = element('stub');
+            animation.add(stubElement);
+            var rootElement = element('root'),
+                subRootElement = element('sub-root');
+            animation.add(rootElement.add(subRootElement.add(searchFor)));
+
+            expect(stubElement.find('foobar')).toBeNull();
+            expect(stubElement.findAll('foobar')).toBeEmpty();
+
+            expect(rootElement.find('foobar').id).toEqual(searchFor.id);
+            expect(rootElement.findAll('foobar')[0].id).toEqual(searchFor.id);
+
+            expect(subRootElement.find('foobar').id).toEqual(searchFor.id);
+            expect(subRootElement.findAll('foobar')[0].id).toEqual(searchFor.id);
+        });
+
+    });
+
+    it('properly searches for multiple elements with a same name', function() {
+        var animation = new anm.Animation();
+        var searchForOne = element('foobar'),
+            searchForTwo = element('foobar');
+        animation.add(element('stub'));
+        animation.add(element('root').add(element('sub-root').add(searchForOne)));
+        animation.add(element('another').add(searchForTwo));
+
+        expect(animation.findAll('foobar')[0].id).toEqual(searchForOne.id);
+        expect(animation.findAll('foobar')[1].id).toEqual(searchForTwo.id);
+    });
+
+    describe('properly searches for an element by path, when', function() {
+
+        it('placed in a root', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('Foobar');
+            animation.add(element('stub'));
+            animation.add(searchFor);
+
+            expect(animation.find('/Foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('/Foobar')[0].id).toEqual(searchFor.id);
+        });
+
+
+        it('placed as a child somewhere deep inside', function() {
+            var animation = new anm.Animation();
+            var searchFor = element('foobar');
+            animation.add(element('stub'));
+            animation.add(element('root').add(element('sub-root').add(searchFor)));
+
+            expect(animation.find('foobar').id).toEqual(searchFor.id);
+            expect(animation.findAll('foobar')[0].id).toEqual(searchFor.id);
+        });
+
+    });
+
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,7 @@
 {
-  "spec_dir": "spec",
+  "src_dir": "/src",
+  "spec_dir": "/spec",
   "spec_files": [
-    "search.spec.js"
+      "**/*[sS]pec.js"
   ]
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "check.spec.js"
+    "search.spec.js"
   ]
 }

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -485,10 +485,12 @@ Animation.prototype._loadRemoteResources = function(player) {
  * Searches for an {@link anm.Element element} by name through another {@link anm.Element element}'s
  * children, or through all the elements in the Animation itself, if no other element was provided.
  *
- * NB: `find` method will be improved soon to support special syntax of searching,
- * so you will be able to search almost everything
+ * You may specify just a name or a full path, if you start it from slash: `/root/sub-element/search-for`.
+ * This way search will ensure element is located exactly at this path and also will visit only the matching elements.
+ * You may specify index instead of name at any place in a full path, by preceding it with semicolon symbol:
+ * `/root/:2/:3`. You may freely mix both indexes and names in one path.
  *
- * @param {String} name Name of the element(s) to find
+ * @param {String} name Name of the element(s) to find or a path
  * @param {anm.Element} [where] Where to search elements for; if omitted, searches in Animation
  *
  * @return {anm.Element} First found element
@@ -503,10 +505,12 @@ Animation.prototype.find = function(selector, where) {
  * Searches for {@link anm.Element elements} by name through another {@link anm.Element element}'s
  * children, or through all the elements in the Animation itself, if no other element was provided.
  *
- * NB: `findAll` method will be improved soon to support special syntax of searching,
- * so you will be able to search almost everything
+ * You may specify just a name or a full path, if you start it from slash: `/root/sub-element/search-for`.
+ * This way search will ensure elements are located exactly at this path.
+ * You may specify index instead of name at any place in a full path, by preceding it with semicolon symbol:
+ * `/root/:2/:3`. You may freely mix both indexes and names in one path.
  *
- * @param {String} name Name of the element(s) to find
+ * @param {String} name Name of the element(s) to find or a path
  * @param {anm.Element} [where] Where to search elements for; if omitted, searches in Animation
  *
  * @return {Array} An array of found elements

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -16,6 +16,7 @@ var events = require('../events.js'),
     errors = require('../errors.js'),
     ErrLoc = require('../loc.js').Errors;
 
+var Search = require('./search.js');
 
 /* X_ERROR, X_FOCUS, X_RESIZE, X_SELECT, touch events */
 
@@ -493,30 +494,7 @@ Animation.prototype._loadRemoteResources = function(player) {
  * @return {anm.Element} First found element
  */
 Animation.prototype.find = function(selector, where) {
-    if (selector[0] === '/') {
-        var path = selector.slice(1).split('/');
-        var nextName = null,
-            nextElms = where ? where.children : this.tree,
-            target = null;
-        while (nextName = path.pop()) { // FIXME: nextName could be ''
-            for (var i = 0, l = nextElms.length; i < l; i++) {
-                if (nextElms[i].name === nextName) {
-                    target = nextElms[i];
-                    nextElms = target.children;
-                    break;
-                }
-            }
-        }
-        return target;
-    } else {
-        var nextElms = where ? where.children : this.tree;
-        var found = null;
-        for (var i = 0, l = nextElms.length; i < l; i++) {
-            if (nextElms[i].name === selector) return nextElms[i];
-            if (found = this.find(selector, nextElms[i])) return found;
-        }
-        return found;
-    };
+    return Search.one(selector).over(where ? where.children : this.tree);
 };
 
 /**
@@ -534,14 +512,7 @@ Animation.prototype.find = function(selector, where) {
  * @return {Array} An array of found elements
  */
 Animation.prototype.findAll = function(selector, where) {
-    where = where || this;
-    var name = selector;
-    var found = [];
-    if (where.name == name) found.push(name);
-    where.traverse(function(elm)  {
-        if (elm.name == name) found.push(elm);
-    });
-    return found;
+    return Search.all(selector).over(where ? where.children : this.tree);
 };
 
 /**

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -2267,16 +2267,29 @@ Element.prototype.toString = function() {
  *
  * Find any element inside this element by its name.
  *
- * See also {@link anm.Animation#find animation.find}.
+ * See also {@link anm.Animation#find animation.find} for information on nice
+ * search abilities provided using special syntax.
  *
- * NB: `find` method will be improved soon to support special syntax of searching,
- * so you will be able to search almost everything.
- *
- * @param {String} name name of the element to search for
+ * @param {String} name name of the element to search for, or a selector
  * @return {anm.Element|Null} found element or `null`
  */
 Element.prototype.find = function(name) {
-    this.anim.find(name, this);
+    return this.anim.find(name, this);
+};
+
+/**
+ * @method find
+ *
+ * Find all the element inside this element matching to given name.
+ *
+ * See also {@link anm.Animation#findAll animation.findAll} for information on nice
+ * search abilities provided using special syntax.
+ *
+ * @param {String} name name of the element to search for, or a selector
+ * @return {[anm.Element]} found elements
+ */
+Element.prototype.findAll = function(name) {
+    return this.anim.findAll(name, this);
 };
 
 /**

--- a/src/anm/animation/search.js
+++ b/src/anm/animation/search.js
@@ -1,0 +1,81 @@
+function Search(spec) {
+    this.selector = spec.selector;
+    this.multiple = spec.multiple;
+    this.anywhere = (spec.selector[0] !== '/'); // search on all levels with one token
+    this.tokens = (spec.selector[0] === '/') ? spec.selector.split('/').slice(1) : [ spec.selector ];
+};
+Search.prototype.over = function(elements) {
+    if (!this.multiple &&  this.anywhere) return search_one_anywhere(elements, this.tokens[0]);
+    if ( this.multiple &&  this.anywhere) return search_all_anywhere([], elements, this.tokens[0]);
+    if (!this.multiple && !this.anywhere) return search_one_by_path(elements, this.tokens);
+    if ( this.multiple && !this.anywhere) return search_all_by_path([], elements, this.tokens);
+};
+
+function matches(element, token, idx) {
+    return (((token[0] === ':') && (idx === parseInt(token.slice(1)))) ||
+            (token === element.name));
+}
+
+function search_one_anywhere(elements, token) {
+    for (var i = 0; i < elements.length; i++) {
+        if (matches(elements[i], token, i)) return elements[i];
+        var result = search_one_anywhere(elements[i].children, token);
+        if (result) return result;
+    }
+    return null;
+}
+
+function search_all_anywhere(results, elements, token) {
+    for (var i = 0; i < elements.length; i++) {
+        if (matches(elements[i], token, i)) results.push(elements[i]);
+        search_all_anywhere(results, elements[i].children, token);
+    }
+    return results;
+}
+
+function search_one_by_path(elements, tokens, level) {
+    level = level || 0;
+    if ((tokens.length === 0) || (level >= tokens.length)) return null;
+    var token = tokens[level];
+    var lastLevel = (level === (tokens.length - 1));
+    for (var i = 0; i < elements.length; i++) {
+        if (matches(elements[i], token, i)) {
+            if (lastLevel) return elements[i];
+            else {
+                var result = search_one_by_path(elements[i].children, tokens, level + 1);
+                if (result) return result;
+            }
+        }
+    }
+    return null;
+}
+
+function search_all_by_path(results, elements, tokens, level) {
+    level = level || 0;
+    if ((tokens.length === 0) || (level >= tokens.length)) return results;
+    var token = tokens[level];
+    var lastLevel = (level === (tokens.length - 1));
+    for (var i = 0; i < elements.length; i++) {
+        if (matches(elements[i], token, i)) {
+            if (lastLevel) results.push(elements[i]);
+            else search_all_by_path(results, elements[i].children, tokens, level + 1);
+        }
+    }
+    return results;
+}
+
+Search.one = function(selector) {
+    return new Search({
+        selector: selector,
+        multiple: false
+    });
+}
+
+Search.all = function(selector) {
+    return new Search({
+        selector: selector,
+        multiple: true
+    });
+}
+
+module.exports = Search;

--- a/src/engine/dom-engine.js
+++ b/src/engine/dom-engine.js
@@ -7,11 +7,16 @@
  * @VERSION
  */
 
+
 // DOM Engine
 // -----------------------------------------------------------------------------
 
-var $doc = window.document;
-    // DomEngine constants
+var $win = (typeof window !== 'undefined') ? window : {}
+var $doc = (typeof window !== 'undefined') ? window.document : {};
+var $nav = (typeof navigator !== 'undefined') ? navigator : {};
+var $glob = (typeof global !== 'undefined') ? global : {};
+
+// DomEngine constants
 
 var MARKER_ATTR = 'anm-player', // marks player existence on canvas element
     AUTO_MARKER_ATTR = 'anm-player-target', // marks that this element is a target for a player
@@ -99,21 +104,21 @@ var $DE = {};
 
 // Framing
 // shim adopted from https://gist.github.com/paulirish/1579671
-var requestAnimationFrame = global.requestAnimationFrame,
-    cancelAnimationFrame = global.cancelAnimationFrame;
+var requestAnimationFrame = $glob.requestAnimationFrame,
+    cancelAnimationFrame = $glob.cancelAnimationFrame;
 var lastTime = 0;
     var vendors = ['ms', 'moz', 'webkit', 'o'];
-    for(var x = 0; x < vendors.length && !global.requestAnimationFrame; ++x) {
-        requestAnimationFrame = global[vendors[x]+'RequestAnimationFrame'];
-        cancelAnimationFrame = global[vendors[x]+'CancelAnimationFrame'] ||
-                                   global[vendors[x]+'CancelRequestAnimationFrame'];
+    for(var x = 0; x < vendors.length && !$glob.requestAnimationFrame; ++x) {
+        requestAnimationFrame = $glob[vendors[x]+'RequestAnimationFrame'];
+        cancelAnimationFrame = $glob[vendors[x]+'CancelAnimationFrame'] ||
+                               $glob[vendors[x]+'CancelRequestAnimationFrame'];
     }
 
     if (!requestAnimationFrame) {
         requestAnimationFrame = function(callback, element) {
             var currTime = new Date().getTime();
             var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+            var id = $win.setTimeout(function() { callback(currTime + timeToCall); },
               timeToCall);
             lastTime = currTime + timeToCall;
             return id;
@@ -130,14 +135,14 @@ $DE.getCancelFrameFunc = function(){ return cancelAnimationFrame; };
 
 // Global things
 
-$DE.PX_RATIO = window.devicePixelRatio || 1;
+$DE.PX_RATIO = $win.devicePixelRatio || 1;
 
 $DE.ajax = function(url, callback, errback, method, headers) {
     var req;
     if (isIE9) {
-        req = new window.XDomainRequest();
+        req = new $win.XDomainRequest();
     } else {
-        req = new window.XMLHttpRequest();
+        req = new $win.XMLHttpRequest();
     }
 
     if (!req) {
@@ -447,7 +452,7 @@ $DE.assignPlayerToWrapper = function(wrapper, player, backup_id) {
     }
 
     var canvasWasPassed = (wrapper.tagName == 'canvas') || (wrapper.tagName == 'CANVAS');
-    if (canvasWasPassed && window.console) {
+    if (canvasWasPassed && $win.console) {
         console.warn('NB: A <canvas> tag was passed to the anm.Player as an element to attach to. This is ' +
                      'not a recommended way since version 1.2; this <canvas> will be moved inside ' +
                      'a <div>-wrapper because of it, so it may break document flow and/or CSS styles. ' +
@@ -782,7 +787,7 @@ $DE.addCanvasOverlay = function(id, player_cvs, conf, callback) {
         w = conf[2], h = conf[3];
     var pconf = $DE.getCanvasSize(player_cvs),
         pw = pconf[0], ph = pconf[1];
-    var p_style = window.getComputedStyle ? window.getComputedStyle(player_cvs) : player_cvs.currentStyle;
+    var p_style = $win.getComputedStyle ? $win.getComputedStyle(player_cvs) : player_cvs.currentStyle;
     var x_shift = parseFloat(p_style.getPropertyValue('border-left-width')),
         y_shift = parseFloat(p_style.getPropertyValue('border-top-width'));
     var new_w = (w * pw),
@@ -856,7 +861,7 @@ $DE.unsubscribeElementEvents = function(elm, handlers) {
 }
 
 $DE.subscribeWindowEvents = function(handlers) {
-    $DE.subscribeElementEvents(window, handlers);
+    $DE.subscribeElementEvents($win, handlers);
 };
 
 $DE.subscribeCanvasEvents = $DE.subscribeElementEvents;
@@ -957,60 +962,60 @@ $DE.createStatImg = function() {
 };
 
 $DE.createStyle = function() {
-    var style = document.createElement('style');
+    var style = $doc.createElement('style');
     style.type = 'text/css';
     return style;
 };
 
 $DE.createAudio = function() {
-    return document.createElement('audio');
+    return $doc.createElement('audio');
 };
 
 $DE.createVideo = function() {
-    return document.createElement('video');
+    return $doc.createElement('video');
 };
 
 $DE.createSource = function() {
-    return document.createElement('source');
+    return $doc.createElement('source');
 };
 
 $DE.appendToBody = function(element) {
-    document.body.appendChild(element);
+    $doc.body.appendChild(element);
 };
 
-var testCanvas = document.createElement('canvas');
+var testCanvas = $doc.createElement ? $doc.createElement('canvas') : {};
 $DE.canvasSupported = !!(testCanvas.getContext && testCanvas.getContext('2d'));
 
-var https = window.location && window.location.protocol === 'https:';
+var https = $win.location && $win.location.protocol === 'https:';
 $DE.isHttps = https;
 
-var local = window.location && window.location.protocol === 'file:';
+var local = $win.location && $win.location.protocol === 'file:';
 $DE.isLocal = local;
 
-var isIE9 = navigator.userAgent.indexOf('MSIE 9.0') !== -1;
+var isIE9 = $nav.userAgent && $nav.userAgent.indexOf('MSIE 9.0') !== -1;
 $DE.isIE9 = isIE9;
 
 var hidden, visibilityChange;
-if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+if (typeof $doc.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
   hidden = "hidden";
   visibilityChange = "visibilitychange";
-} else if (typeof document.mozHidden !== "undefined") {
+} else if (typeof $doc.mozHidden !== "undefined") {
   hidden = "mozHidden";
   visibilityChange = "mozvisibilitychange";
-} else if (typeof document.msHidden !== "undefined") {
+} else if (typeof $doc.msHidden !== "undefined") {
   hidden = "msHidden";
   visibilityChange = "msvisibilitychange";
-} else if (typeof document.webkitHidden !== "undefined") {
+} else if (typeof $doc.webkitHidden !== "undefined") {
   hidden = "webkitHidden";
   visibilityChange = "webkitvisibilitychange";
 }
 
-if (typeof document[hidden] !== 'undefined' ||
-    typeof document.addEventListener !== 'undefined') {
-        document.addEventListener(visibilityChange,
+if (typeof $doc[hidden] !== 'undefined' ||
+    typeof $doc.addEventListener !== 'undefined') {
+        $doc.addEventListener(visibilityChange,
             function() {
                 if (onDocumentHiddenChange) {
-                    onDocumentHiddenChange(document[hidden]);
+                    onDocumentHiddenChange($doc[hidden]);
                 }
             }, false);
 }
@@ -1019,11 +1024,11 @@ $DE.onDocumentHiddenChange = function(cb){
     onDocumentHiddenChange = cb;
 };
 
-$DE.Path2D = global.Path2D;
+$DE.Path2D = $glob.Path2D;
 
 
 $DE.isInIframe = function() {
-    return global.self !== global.top;
+    return $glob.self !== $glob.top;
 };
 
 var iframe = $DE.isInIframe() ? global : null;
@@ -1042,10 +1047,10 @@ $DE.getIframeSrc = function() {
 };
 
 $DE.addMessageListener = function(listener) {
-    if (!global.addEventListener) {
+    if (!$glob.addEventListener) {
         return;
     }
-    global.addEventListener('message', listener, false);
+    $glob.addEventListener('message', listener, false);
 };
 
 $DE.postToContentWindow = function(message) {


### PR DESCRIPTION
Add the ability to search with path in a way like: `/root/sub-element/some-name`, or even with indexes (they depend on the order elements were added to a tree): `/:1/:2/some-name`.