### PR TITLE
[play-639] postpone the load completion

### DIFF
--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -375,20 +375,22 @@ Player.prototype.load = function(arg1, arg2, arg3, arg4) {
                     if (player.anim === result) { // avoid race condition when there were two requests
                         // to load different animations and first one finished loading
                         // after the second one
-                        player.state.happens = C.LOADING;
-                        player.fire(C.S_CHANGE_STATE, C.LOADING);
-                        player.fire(C.S_LOAD, result);
-                        player._updateMediaVolumes();
-                        if (!player.handleEvents) player.stop();
-                        player._callPostpones();
-                        if (callback) callback.call(player, result);
-                        // player may appear already playing something if autoPlay or a similar time-jump
-                        // flag was set from some different source of options (async, for example),
-                        // then the rule (for the moment) is: last one wins
-                        if (player.autoPlay) {
-                            if (player.state.happens === C.PLAYING) player.stop();
-                            player.play();
-                        }
+                        utils.postpone(function(){
+                            player.state.happens = C.LOADING;
+                            player.fire(C.S_CHANGE_STATE, C.LOADING);
+                            player.fire(C.S_LOAD, result);
+                            player._updateMediaVolumes();
+                            if (!player.handleEvents) player.stop();
+                            player._callPostpones();
+                            if (callback) callback.call(player, result);
+                            // player may appear already playing something if autoPlay or a similar time-jump
+                            // flag was set from some different source of options (async, for example),
+                            // then the rule (for the moment) is: last one wins
+                            if (player.autoPlay) {
+                                if (player.state.happens === C.PLAYING) player.stop();
+                                player.play();
+                            }
+                        });
                     }
                 }
             ], function(url, factor, progress, errors) {

--- a/src/anm/utils.js
+++ b/src/anm/utils.js
@@ -130,7 +130,7 @@ function fmt_time(time) {
     return ((time < 0) ? '-' : '') +
             ((h > 0)  ? (((h < 10) ? ('0' + h) : h) + ':') : '') +
             ((m < 10) ? ('0' + m) : m) + ':' +
-            ((s < 10) ? ('0' + s) : s)
+            ((s < 10) ? ('0' + s) : s);
 }
 
 function ell_text(text, max_len) {
@@ -188,7 +188,7 @@ function mrg_obj(src, backup, trg) {
     if (!backup) return src;
     var res = trg || {};
     for (var prop in backup) {
-        res[prop] = is.defined(src[prop]) ? src[prop] : backup[prop]; };
+        res[prop] = is.defined(src[prop]) ? src[prop] : backup[prop]; }
     return res;
 }
 
@@ -242,6 +242,12 @@ function removeElement(obj, element) {
     }
 }
 
+function postpone(fn) {
+    //run the code after the event loop is done with whatever it is
+    //occupied with at the moment
+    setTimeout(fn, 0);
+}
+
 // TODO: add array cloning
 
 module.exports = {
@@ -259,5 +265,6 @@ module.exports = {
     is: is,
     iter: iter,
     keys: keys,
-    removeElement: removeElement
+    removeElement: removeElement,
+    postpone: postpone
 };


### PR DESCRIPTION
When the resources are loaded from cache, the player’s `stop` method and some of the other updates are fired before the elements get to know they’re ready. This leads to all the kinds of weird things like the thumbnail being drawn only with vector shapes and not images, like in PLAY-639.

This can be remedied with a rewrite of the ResourceManager (which should be done later anyway), but a simple and working method to fix it right away is just let the event loop do its job before calling `stop` and considering the load complete. This is how it is done here.
