### PR TITLE
A number of fixes for mouse event handling.

### DIFF
--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -388,7 +388,7 @@ Animation.prototype.filterEvent = function(type, evt) {
         var targetFound = false;
         var moSubscriber = null; // mouse-out subscriber
         if (type === 'mouseclick') console.log(':::: start checking for click at ', pos.x, pos.y);
-        anim.each(function(child) {
+        anim.each(function(child) { // iterates over
             child.inside(pos, function(elm) { // filter elements
                 if (type === 'mouseclick') console.log('checking:', elm.name, ', parent:', elm.parent ? elm.parent.name : 'None');
                 if (type === 'mouseclick') {
@@ -402,13 +402,14 @@ Animation.prototype.filterEvent = function(type, evt) {
                 if (type !== 'mousemove') {
                     if (subscriber) subscriber.fire(type, evt);
                 } else { // type === 'mousemove'
+
                     // check mouseover/mouseout
                     if (!anim.__lastOverElm) {
                         // mouse moved over this element first time
                         anim.__lastOverElm = elm; // not a subscriber!
                         if (subscriber) {
                             subscriber.fire('mouseover', evt);
-                            subscriber.fire(type, evt); // fire mousemove next to mouseover
+                            subscriber.fire(type, evt); // fire this mousemove next to mouseover
                         }
                     } else {
                         if (elm.id === anim.__lastOverElm.id) { // mouse is still over this element
@@ -423,13 +424,15 @@ Animation.prototype.filterEvent = function(type, evt) {
                             anim.__lastOverElm = elm; // not a subscriber!
                             if (subscriber) {
                                 subscriber.fire('mouseover', evt);
-                                subscriber.fire(type, evt); // fire mousemove next to mouseover
+                                subscriber.fire(type, evt); // fire this mousemove next to mouseover
                             }
                         }
                     }
+
                 }
-                return false; /* stop iteration, so first matched element exits the check */
+                return false; /* stop inner iteration, so first matched element exits the check */
             });
+            if (targetFound) return false; /* stop outer iteration, so first matched element exits the check */
         });
         if ((type === 'mousemove') && !targetFound && anim.__lastOverElm) {
             var stillInside = false;

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -254,9 +254,6 @@ Animation.prototype.render = function(ctx, time, dt) {
  * @param {Number} time
  */
 Animation.prototype.jump = function(t) {
-    // this.traverse(function(elm) {
-    //     elm.resetTime();
-    // });
     if (this.jumping) return;
     this.jumping = true;
     utils.keys(this.targets, function(id, player) {
@@ -306,6 +303,7 @@ Animation.prototype.getFittingDuration = function() {
  */
 Animation.prototype.reset = function() {
     this.__informEnabled = true;
+    this.time = null;
     this.each(function(child) {
         child.reset();
     });
@@ -410,6 +408,7 @@ Animation.prototype.filterEvent = function(type, evt) {
         var pos = anim.adapt(evt.pos.x, evt.pos.y);
         var targetFound = false;
         var moSubscriber = null; // mouse-out subscriber
+        var clickEvent = (type === 'mouseclick') || (type === 'mousedoubleclick');
         anim.reverseEach(function(child) {
             child.inside(pos, function(elm) { // filter elements
                 return is.defined(elm.cur_t) && elm.fits(elm.cur_t);
@@ -419,7 +418,6 @@ Animation.prototype.filterEvent = function(type, evt) {
                 if (type !== 'mousemove') {
                     if (subscriber) subscriber.fire(type, evt);
                 } else { // type === 'mousemove'
-
                     // check mouseover/mouseout
                     if (!anim.__lastOverElm) {
                         // mouse moved over this element first time
@@ -447,9 +445,9 @@ Animation.prototype.filterEvent = function(type, evt) {
                     }
 
                 }
-                return false; /* stop inner iteration, so first matched element exits the check */
+                if (clickEvent) return false; /* stop inner iteration, so first matched element exits the check */
             });
-            if (targetFound) return false; /* stop outer iteration, so first matched element exits the check */
+            if (targetFound && clickEvent) return false; /* stop outer iteration, so first matched element exits the check */
         });
         if ((type === 'mousemove') && !targetFound && anim.__lastOverElm) {
             var stillInside = false;

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -380,12 +380,11 @@ Animation.prototype.handle__x = function(type, evt) {
         if (type === 'mouseclick') console.log(':::: start checking for click at ', pos.x, pos.y);
         anim.each(function(child) {
             child.inside(pos, function(elm) { // filter elements
-                if (type === 'mouseclick') console.log('checking:', elm.name);
-                if ((type === 'mouseclick') && elm.subscribedTo(type)) {
-                    console.log(elm.name, ': anim.time', anim.time, '/ cur_t', elm.cur_t, '/ fits', elm.fits(elm.cur_t));
+                if (type === 'mouseclick') console.log('checking:', elm.name, ', parent:', elm.parent ? elm.parent.name : 'None');
+                if (type === 'mouseclick') {
+                    console.log(elm.name, ': anim.time', anim.time, '/ cur_t', elm.cur_t, '/ band', elm.lband[0], elm.lband[1], '/ fits', elm.fits(elm.cur_t));
                 }
-                return elm.subscribedTo(type) &&
-                       is.defined(elm.cur_t) && elm.fits(elm.cur_t);
+                return is.defined(elm.cur_t) && elm.fits(elm.cur_t);
             }, function(elm, local_pos) { // point is inside
                 if (type === 'mouseclick') console.log('matched:', elm.name);
                 foundTarget = true;

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -201,6 +201,7 @@ Animation.prototype.iter = function(func, rfunc) {
  */
 Animation.prototype.render = function(ctx, time, dt) {
     ctx.save();
+    this.time = time;
     var zoom = this.zoom;
     if (zoom != 1) {
         ctx.scale(zoom, zoom);
@@ -225,6 +226,9 @@ Animation.prototype.render = function(ctx, time, dt) {
  * @param {Number} time
  */
 Animation.prototype.jump = function(t) {
+    // this.traverse(function(elm) {
+    //     elm.resetTime();
+    // });
     utils.keys(this.targets, function(id, player) {
         if (player) player.seek(t);
     });
@@ -365,7 +369,8 @@ Animation.prototype.handle__x = function(type, evt) {
         var foundTarget = false;
         anim.each(function(child) {
             child.inside(pos, function(elm) { // filter elements
-                return elm.subscribedTo(type);
+                return elm.subscribedTo(type) &&
+                       is.defined(elm.cur_t) && elm.fits(elm.cur_t);
             }, function(elm, local_pos) { // point is inside
                 foundTarget = true;
                 if (type !== 'mousemove') {

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -411,7 +411,7 @@ Animation.prototype.filterEvent = function(type, evt) {
         var targetFound = false;
         var moSubscriber = null; // mouse-out subscriber
         if (type === 'mouseclick') console.log(':::: start checking for click at ', pos.x, pos.y);
-        anim.each(function(child) {
+        anim.reverseEach(function(child) {
             child.inside(pos, function(elm) { // filter elements
                 if (type === 'mouseclick') console.log('checking:', elm.name, ', parent:', elm.parent ? elm.parent.name : 'None');
                 if (type === 'mouseclick') {

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -410,17 +410,10 @@ Animation.prototype.filterEvent = function(type, evt) {
         var pos = anim.adapt(evt.pos.x, evt.pos.y);
         var targetFound = false;
         var moSubscriber = null; // mouse-out subscriber
-        if (type === 'mouseclick') console.log(':::: start checking for click at ', pos.x, pos.y);
         anim.reverseEach(function(child) {
             child.inside(pos, function(elm) { // filter elements
-                if (type === 'mouseclick') console.log('checking:', elm.name, ', parent:', elm.parent ? elm.parent.name : 'None');
-                if (type === 'mouseclick') {
-                    console.log(elm.name, ': anim.time', anim.time, '/ cur_t', elm.cur_t, '/ band',
-                                elm.lband[0], elm.lband[1], '/ fits', is.defined(elm.cur_t) && elm.fits(elm.cur_t));
-                }
                 return is.defined(elm.cur_t) && elm.fits(elm.cur_t);
             }, function(elm, local_pos) { // point is inside
-                if (type === 'mouseclick') console.log('matched:', elm.name);
                 targetFound = true;
                 var subscriber = firstSubscriber(elm, type);
                 if (type !== 'mousemove') {

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -2070,9 +2070,8 @@ Element.prototype.myBounds = function() {
  * Test if a point given in global coordinate space is located inside the element's bounds
  * or one of its children and calls given function for found elements.
  *
- * NB: Do NOT consider `.inside(...)`'s returned value as a positive result of the test for a
- * point position—in case of positive check, `fn` is called. Return value of this function is
- * has a special purpose for iteration.
+ * NB: `.inside(...)` is NOT returning the result of a test. It only calls an `fn` callback if
+ * test passed.
  *
  * @param {Object} pt point to check
  * @param {Number} pt.x
@@ -2084,18 +2083,17 @@ Element.prototype.myBounds = function() {
  * @param {Function} filter function to filter elements before checking bounds, since it's quite a slow operation
  * @param {anm.Element} filter.elm element to check
  * @param {Boolean} filter.return return `true` if this element should be checked, `false` if not
- * @return {Boolean} _DO NOT USE_, see notice above for explanation :)
  */
 Element.prototype.inside = function(pt, filter, fn) {
     var passed_filter = !filter || filter(this);
-    if (!passed_filter && !this.hasChildren()) return /* continue */;
+    if (!passed_filter && !this.hasChildren()) return;
     var local_pt = this.adapt(pt.x, pt.y);
     if (passed_filter && this.myBounds().inside(local_pt)) {
         var subj = this.$path || this.$text || this.$image || this.$video;
         if (subj && subj.inside(local_pt)) return fn(this, local_pt);
     } else {
         this.each(function(elm) {
-            return elm.inside(local_pt, filter, fn);
+            elm.inside(local_pt, filter, fn);
         });
     }
 };

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -303,18 +303,19 @@ Element.prototype.initTime = function() {
     this.lband = [0, Element.DEFAULT_LEN]; // local band
     this.gband = [0, Element.DEFAULT_LEN]; // global band
 
-    /** @property {Number} t TODO (local time) */
+    /** @property {Number} t (local time) */
     /** @property {Number} dt TODO (a delta in local time from previous render) */
-    /** @property {Number} rt TODO (time position, relative to band) */
-    /** @property {String} key TODO (time position by a key name) */
-    /** @property {Object} keys TODO (a map of keys -> time) @readonly */
-    /** @property {Function} tf TODO (time function) */
+    /** @property {Number} rt (time position, relative to band duration) */
+    /** @property {String} key (time position by a key name) */
+    /** @property {Object} keys (a map of keys -> time) @readonly */
+    /** @property {Function} tf (time function) */
 
     this.keys = {}; // aliases for time jumps
     this.tf = null; // time jumping function
 
     this.key = null;
     this.t = null;
+    this.rt = null;
 
     this.__resetTimeFlags();
 
@@ -1180,7 +1181,9 @@ Element.prototype.freeze = function() {
     this.frozen = true;
     this.__m_freeze = function(t) {
         if (!this.frozen) return;
-        if (is.defined(this.pausedAt)) this.t = this.pausedAt;
+        if (is.defined(this.pausedAt)) {
+            this.t = this.pausedAt;
+        }
         else (this.pausedAt = t);
     };
     this.modify(this.__m_freeze);
@@ -1199,6 +1202,8 @@ Element.prototype.freeze = function() {
  */
 Element.prototype.unfreeze = function() {
     this.frozen = false;
+    this.t = null;
+    this.pausedAt = undefined;
     if (this.__m_freeze) this.unmodify(this.__m_freeze);
     return this;
 }
@@ -2503,8 +2508,9 @@ Element.prototype.__checkJump = function(at) {
     // directly or relatively or with key,
     // get its absolute local value
     t = (is.defined(this.p)) ? this.p : null;
-    t = ((t === null) && (this.t !== null) && is.finite(duration)) ?
-        this.t * duration : t;
+    t = ((t === null) && (this.t !== null)) ? this.t : t;
+    t = ((t === null) && (this.rt !== null) && is.finite(duration)) ?
+        this.rt * duration : t;
     t = ((t === null) && (is.defined(this.key))) ?
         this.keys[this.key] : t;
     if (t !== null) {

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -324,7 +324,6 @@ Element.prototype.initTime = function() {
 
 Element.prototype.resetTime = Element.prototype.initTime;
 Element.prototype.__resetTimeCache = function() {
-    console.log(this.name, 'reset time');
     this.cur_t = null; // system-defined
     this.cur_rt = null; // system-defined
 
@@ -557,7 +556,6 @@ Element.prototype.modifiers = function(ltime, dt, types) {
     // copy current state as previous one
     elm.applyPrevState(elm);
 
-    if (ltime === 10) console.log('set ltime to 10 / ', elm.name);
     elm.cur_t  = ltime;
     elm.cur_rt = ltime / (elm.lband[1] - elm.lband[0]);
 
@@ -792,8 +790,9 @@ Element.prototype.render = function(ctx, gtime, dt) {
     // these values will be set to proper values in `.modifiers` call below,
     // only if `.fits` check was passed. if not, they both should be set to `null`,
     // this means system tried to render this element, but element missed the gap
-    // (so while animation flows, elements outside of time will always reset their time).
-    if (this.name === '2') console.log('reset time for', this.name);
+    // (so while animation flows, elements outside of time will always reset their time,
+    // even if no 'bandstop' event was fired for them — this could happen with sequences
+    // of jumps in time).
     this.cur_t  = null;
     this.cur_rt = null;
 

--- a/src/anm/events.js
+++ b/src/anm/events.js
@@ -45,7 +45,7 @@ function provideEvents(subj, events) {
         if (!this.handlers) throw errors.system('Instance is not initialized with handlers, call __initHandlers in its constructor');
         if (!this.provides(event)) throw errors.system('Event \'' + event +
                                                  '\' is not provided by ' + this);
-        if (this.handle__x && !(this.handle__x.apply(this, arguments))) return;
+        if (this.filterEvent && !(this.filterEvent.apply(this, arguments))) return;
         if (this['handle_'+event] || this.handlers[event].length) {
             var evt_args = new Array(arguments.length - 1);
             for (var i = 1; i < arguments.length; i++) {

--- a/src/anm/graphics/path.js
+++ b/src/anm/graphics/path.js
@@ -320,7 +320,7 @@ Path.prototype.pointAt = function(t) {
  * @param {Number} pt.y
  * @return {Boolean} is point inside
  */
- Path.prototype.inside = function(pt) {
+Path.prototype.inside = function(pt) {
     var x = pt.x, y = pt.y;
 
     var mask = /*(windingRule == WIND_NON_ZERO ?*/ -1 /*: 1)*/;

--- a/src/anm/player.js
+++ b/src/anm/player.js
@@ -886,7 +886,7 @@ Player.prototype.drawAt = function(time) {
                                                              // postpone this task and exit. postponed tasks
                                                              // will be called when all remote resources were
                                                              // finished loading
-    if ((time < 0) || (time > this.anim.duration)) {
+    if ((time < 0) || (!this.infiniteDuration && (time > this.anim.duration))) {
         throw errors.player(utils.strf(ErrLoc.P.PASSED_TIME_NOT_IN_RANGE, [time]), this);
     }
     var anim = this.anim,

--- a/src/anm/player_manager.js
+++ b/src/anm/player_manager.js
@@ -25,7 +25,7 @@ function PlayerManager() {
 
 events.provideEvents(PlayerManager, [ C.S_NEW_PLAYER, C.S_PLAYER_DETACH ]);
 
-PlayerManager.prototype.handle__x = function(evt, player) {
+PlayerManager.prototype.filterEvent = function(evt, player) {
     if (evt == C.S_NEW_PLAYER) {
         this.hash[player.id] = player;
         this.instances.push(player);

--- a/src/anm/player_manager.js
+++ b/src/anm/player_manager.js
@@ -55,7 +55,7 @@ PlayerManager.prototype.getPlayer = function(cvs_id) {
  */
 PlayerManager.prototype.handleDocumentHiddenChange = function(hidden) {
     var i, player;
-    for(i=0;i<this.instances.length;i++) {
+    for(i=0; i<this.instances.length; i++) {
         player = this.instances[i];
         if (hidden && player.state.happens === C.PLAYING) {
             player._pausedViaHidden = true;

--- a/src/anm/utils.js
+++ b/src/anm/utils.js
@@ -114,9 +114,13 @@ function keys(obj, f) {
     // TODO: grep -r ./src -e "var .* in" -> use everywhere?
     if (Object.keys) {
         var ids = Object.keys(obj);
-        for (var i = 0; i < ids.length; i++) f(ids[i], obj[ids[i]]);
+        for (var i = 0; i < ids.length; i++) {
+            if (f(ids[i], obj[ids[i]]) === false) break;
+        }
     } else {
-        for (var id in obj) f(id, obj[id]);
+        for (var id in obj) {
+            if (f(id, obj[id]) === false) break;
+        };
     }
 }
 


### PR DESCRIPTION
Mouse event check now goes over the children in reverse order, so top elements (with higher _virtual_ z-index) are checked first. First element found for a `mouseclick` and matched by its time is the only one that handles this event. Other mouse events still check all matched elements. If element is not subscribed to the mouse event, it is passed to the first `parent` which is subscribed

Also includes:
* weird `handle__x` from `events.js` is now renamed to a friendly `filterEvent`;
* `Animation.each`, `Animation.traverse`, `Element.each`, `utils.keys` can now be exited by explicitly returning `false` from the iteration function;
* `Animation.reverseEach`, `Element.reverseEach`, for searches which should first visit top elements _(or should `.each` always work like that?)_;
* `element.inside()` improvements;
* `animation.time` now stores the last time it was rendered, or `null`;
* `element.cur_t` / `element.cur_rt` instance properties now store the local time of last render (considering all the jumps in time could happen), or `null`;
* fix for `player.drawAt` to check `player.infiniteDuration` flag before firing the error about duration (happened in sandbox when you move it to background tab and return later, so it un-pauses and starts playing from where it was stopped at, but checked if time matches animation duration)