### PR TITLE
Move player's CSS to a separate file

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -860,7 +860,7 @@ task('browserify', { 'async': true }, function() {
     if (!fs.existsSync(browserifyPath)) {
         browserifyPath = './node_modules/browserify/bin/cmd.js';
     }
-    jake.exec(browserifyPath + ' src/main.js -o dist/player.js', function() {
+    jake.exec(browserifyPath + '-t browserify-css src/main.js -o dist/player.js', function() {
         console.log('dist/player.js created successfully');
         complete();
     });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "aws-sdk": "latest",
     "google-closure-compiler": "latest",
     "browserify": "latest",
+    "browserify-css": "latest",
     "jasmine": "latest"
   },
   "optionalDependencies": {

--- a/res/player.css
+++ b/res/player.css
@@ -1,0 +1,20 @@
+.anm-wrapper {
+    position: relative;
+}
+
+.anm-controls {
+    position: absolute;
+    left: 0;
+    top: 0;
+    vertical-align: top;
+    z-index: 100;
+    cursor: pointer;
+    background-color: rgba(0,0,0,0);
+}
+
+#anm-text-measurer-container {
+    position: absolute;
+    visibility: hidden;
+    left: -10000px;
+    top: -10000px;
+}

--- a/src/engine/dom-engine.js
+++ b/src/engine/dom-engine.js
@@ -230,50 +230,26 @@ $DE.CONTROLS_INSTANCE_CLASS_PREFIX = 'anm-controls-';
 $DE.INFO_CLASS = 'anm-controls';
 $DE.INFO_INSTANCE_CLASS_PREFIX = 'anm-controls-';
 
-$DE.WRAPPER_CSS = '{ position: relative; }';
-
-$DE.CONTROLS_CSS = '{ ' +
-    'position: absolute;' +
-    'left: 0;' +
-    'top: 0;' +
-    'vertical-align: top;' +
-    'z-index: 100;' +
-    'cursor: pointer;' +
-    'background-color: rgba(0,0,0,0);' +
-    ' }';
 
 $DE.ensureGlobalStylesInjected = function() {
     if ($DE.__stylesTag) return;
-    //if (!($doc.readyState === "complete")) return;
     var stylesTag = $doc.getElementById('anm-player-styles');
     if (!stylesTag) {
         stylesTag = $DE.createStyle();
         stylesTag.id = 'anm-player-styles';
+
+        var css = require('../../res/player.css');
+        stylesTag.innerHTML = css;
         // TODO: inject as first element?
-        var head = $doc.getElementsByTagName("head")[0];
+        var head = $doc.head;
         head.appendChild(stylesTag);
 
     }
     $DE.__stylesTag = stylesTag;
-    $DE.addGeneralStyles();
 };
 
-$DE.addGeneralStyles = function() {
-    var styles = $DE.__stylesTag.sheet,
-        rules = styles.cssRules || styles.rules;
-    var insertRule = function(rule) {
-        (styles.insertRule || styles.addRule).call(styles, rule, rules.length);
-    };
-
-    var wrapperRule = '.' + $DE.WRAPPER_CLASS + $DE.WRAPPER_CSS;
-    insertRule(wrapperRule);
-    var controlsRule = '.' + $DE.CONTROLS_CLASS + $DE.CONTROLS_CSS;
-    insertRule(controlsRule);
-};
 
 $DE.injectElementStyles = function(elm, general_class, instance_class) {
-    var styles = $DE.__stylesTag.sheet,
-        rules = styles.cssRules || styles.rules;
     if (elm.classList) {
         elm.classList.add(general_class);
         elm.classList.add(instance_class);
@@ -295,10 +271,6 @@ $DE.createTextMeasurer = function() {
           var div = $doc.createElement('div');
           var span = $doc.createElement('span');
           span.id = 'anm-text-measurer';
-          div.style.visibility = 'hidden';
-          div.style.position = 'absolute';
-          div.style.top = -10000 + 'px';
-          div.style.left = -10000 + 'px';
           div.id = 'anm-text-measurer-container';
           div.appendChild(span);
           $doc.body.appendChild(div);
@@ -544,9 +516,6 @@ $DE.detachPlayer = function(player) {
     if (player.statImg) {
       $DE.detachElement(null, player.statImg);
     }
-    //FIXME: should remove stylesTag when last player was deleted from page
-    //$DE.detachElement(null, $DE.__stylesTag);
-    //$DE.__stylesTag = null;
 };
 
 $DE.getContext = function(cvs, type) {
@@ -739,7 +708,7 @@ $DE.setWrapperSize = function(wrapper, width, height) {
     var props = $DE.getAnmProps(wrapper);
     props.width = _w;
     props.height = _h;
-    wrapper.style.width  = _w + 'px'; 
+    wrapper.style.width  = _w + 'px';
     wrapper.style.height = _h + 'px';
     return [ _w, _h ];
 };


### PR DESCRIPTION
This makes the player’s CSS a lot more maintainable and visible. Will help with the end screen too, as it is a DOM object and requires a lot of styling.

One caveat: if you use `watchify` when developing, you should now launch it like this now:
`watchify -t browserify-css src/main.js -o dist/player.js` or else it will not build.