### PR TITLE
Fix orient to path (again)

### DIFF
--- a/examples/container-with-parameters.html
+++ b/examples/container-with-parameters.html
@@ -2,15 +2,7 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico" />
-    <script src="../src/vendor/matrix.js" type="text/javascript"></script>
-    <script src="../src/vendor/font-detector.js" type="text/javascript"></script>
-    <script src="../src/engine/dom-engine.js" type="text/javascript"></script>
-    <script src="../src/anm.js" type="text/javascript"></script>
-    <script src="../src/player.js" type="text/javascript"></script>
-    <script src="../src/builder.js" type="text/javascript"></script>
-    <script src="../src/module/collisions.js" type="text/javascript"></script>
-    <script src="../src/module/scripting.js" type="text/javascript"></script>
-    <script src="../src/import/animatron-importer.js" type="text/javascript"></script>
+    <script src="../dist/bundle/animatron.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -259,7 +259,7 @@ Tween.register(C.T_ROT_TO_PATH, {
             var path = this.$mpath;
             // when t equals exact 0, it is replaced with 0.001
             // or else returned angle would be 0
-            if (path) this.angle += path.tangentAt(t || 0.001);
+            if (path) this.angle = path.tangentAt(t || 0.001);
         }
     },
     from: nop, to: nop

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -265,6 +265,17 @@ Tween.register(C.T_ROT_TO_PATH, {
     from: nop, to: nop
 });
 
+Tween.register(C.T_MRG_ROT_TO_PATH, function(values) {
+    var _from = values[0],
+        to = values[1];
+    return function(t) {
+        var path = this.$mpath;
+        var angle = _from * (1.0 - t) + to * t;
+        if (path) angle += path.tangentAt(t || 0.001);
+        this.angle = angle;
+    }
+});
+
 Tween.register(C.T_ALPHA, function(values) {
     var _from = values[0],
         to = values[1];

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -259,21 +259,10 @@ Tween.register(C.T_ROT_TO_PATH, {
             var path = this.$mpath;
             // when t equals exact 0, it is replaced with 0.001
             // or else returned angle would be 0
-            if (path) this.angle = path.tangentAt(t || 0.001);
+            if (path) this.angle += path.tangentAt(t || 0.001);
         }
     },
     from: nop, to: nop
-});
-
-Tween.register(C.T_MRG_ROT_TO_PATH, function(values) {
-    var _from = values[0],
-        to = values[1];
-    return function(t) {
-        var path = this.$mpath;
-        var angle = _from * (1.0 - t) + to * t;
-        if (path) angle += path.tangentAt(t || 0.001);
-        this.angle = angle;
-    }
 });
 
 Tween.register(C.T_ALPHA, function(values) {

--- a/src/anm/animation/tween.js
+++ b/src/anm/animation/tween.js
@@ -217,6 +217,7 @@ Tween.register(C.T_TRANSLATE, {
             this.x = p[0];
             this.y = p[1];
             // we should null the moving path, if it was empty
+            this.$mpath_t = t;
             this.$mpath = (path.length() > 0) ? path : null;
         }
     },
@@ -259,7 +260,7 @@ Tween.register(C.T_ROT_TO_PATH, {
             var path = this.$mpath;
             // when t equals exact 0, it is replaced with 0.001
             // or else returned angle would be 0
-            if (path) this.angle += path.tangentAt(t || 0.001);
+            if (path) this.angle += path.tangentAt(this.$mpath_t || 0.001);
         }
     },
     from: nop, to: nop

--- a/src/anm/constants.js
+++ b/src/anm/constants.js
@@ -155,6 +155,7 @@ C.T_TRANSLATE   = 'translate';
 C.T_SCALE       = 'scale';
 C.T_ROTATE      = 'rotate';
 C.T_ROT_TO_PATH = 'rotatetopath';
+C.T_MRG_ROT_TO_PATH = 'mergedrotatetopath';
 C.T_ALPHA       = 'alpha';
 C.T_SHEAR       = 'shear';
 C.T_FILL        = 'fill';

--- a/src/anm/constants.js
+++ b/src/anm/constants.js
@@ -155,7 +155,6 @@ C.T_TRANSLATE   = 'translate';
 C.T_SCALE       = 'scale';
 C.T_ROTATE      = 'rotate';
 C.T_ROT_TO_PATH = 'rotatetopath';
-C.T_MRG_ROT_TO_PATH = 'mergedrotatetopath';
 C.T_ALPHA       = 'alpha';
 C.T_SHEAR       = 'shear';
 C.T_FILL        = 'fill';

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -285,7 +285,6 @@ Import.branch = function(type, src, all, anim) {
         // apply tweens
         if (lsrc[7]) {
             var rotate_tweens = 0;
-            var translates = [];
             var first_rotate = Infinity, last_rotate = 0;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -303,12 +303,12 @@ Import.branch = function(type, src, all, anim) {
                                              .from(0).to(0));
                 }
                 if (last_rotate < Infinity) {
-                    ltrg.tween(Tween.rotate().start(last_rotate).stop(Infinity)
+                    ltrg.tween(Tween.rotate().start(last_rotate).stop(ltrg.lband[1] - ltrg.lband[0])
                                              .from(0).to(0));
                 }
             }
             if (flags & L_ROT_TO_PATH) {
-                ltrg.tween(Tween.rotatetopath().start(0).stop(Infinity));
+                ltrg.tween(Tween.rotatetopath().start(0).stop(ltrg.lband[1] - ltrg.lband[0]));
             }
         }
 

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -287,7 +287,7 @@ Import.branch = function(type, src, all, anim) {
             var rotate_tweens = 0;
             var translates = [];
             var first_rotate = 0, last_rotate = Infinity;
-            //var first_translate = 0, last_translate = Infinity;
+            var first_translate = 0, last_translate = Infinity;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
@@ -298,8 +298,8 @@ Import.branch = function(type, src, all, anim) {
                         last_rotate = Math.min(last_rotate, t.$band[1]);
                         rotate_tweens++;
                     } else if (t.tween_type === C.T_TRANSLATE) {
-                        //first_translate = Math.max(first_translate, t.$band[0]);
-                        //last_translate = Math.min(last_translate, t.$band[1]);
+                        first_translate = Math.max(first_translate, t.$band[0]);
+                        last_translate = Math.min(last_translate, t.$band[1]);
                         translates.push(t);
                     }
                 }
@@ -315,10 +315,8 @@ Import.branch = function(type, src, all, anim) {
                                              .from(0).to(0));
                 }
             }
-            if (flags & L_ROT_TO_PATH && translates.length) {
-                for (var i = 0, il = translates.length; i < il; i++) {
-                    ltrg.tween(Tween.rotatetopath().band(translates[i].$band));
-                }
+            if ((flags & L_ROT_TO_PATH) && translates.length) {
+                ltrg.tween(Tween.rotatetopath().start(0).stop(last_translate);
             }
         }
 

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -444,6 +444,7 @@ Import.band = function(src) {
  */
 // -> Path
 Import.path = function(src) {
+    return null;
     var path = Import._pathDecode(src[4]);
     if (!path) return;
     return new Path(path);

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -287,7 +287,6 @@ Import.branch = function(type, src, all, anim) {
             var rotate_tweens = 0;
             var translates = [];
             var first_rotate = 0, last_rotate = Infinity;
-            var first_translate = 0, last_translate = Infinity;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
@@ -297,10 +296,6 @@ Import.branch = function(type, src, all, anim) {
                         first_rotate = Math.max(first_rotate, t.$band[0]);
                         last_rotate = Math.min(last_rotate, t.$band[1]);
                         rotate_tweens++;
-                    } else if (t.tween_type === C.T_TRANSLATE) {
-                        first_translate = Math.max(first_translate, t.$band[0]);
-                        last_translate = Math.min(last_translate, t.$band[1]);
-                        translates.push(t);
                     }
                 }
                 ltrg.tween(t);
@@ -315,8 +310,8 @@ Import.branch = function(type, src, all, anim) {
                                              .from(0).to(0));
                 }
             }
-            if ((flags & L_ROT_TO_PATH) && translates.length) {
-                ltrg.tween(Tween.rotatetopath().start(0).stop(last_translate);
+            if (flags & L_ROT_TO_PATH) {
+                ltrg.tween(Tween.rotatetopath().start(0).stop(Infinity));
             }
         }
 

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -284,13 +284,30 @@ Import.branch = function(type, src, all, anim) {
 
         // apply tweens
         if (lsrc[7]) {
+            var rotate_tweens;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
                 if (!t) continue;
-                ltrg.tween(t);
+                if ((flags & L_ROT_TO_PATH) && (t.tween_type === C.T_ROTATE)) {
+                    if (!rotate_tweens) rotate_tweens = [];
+                    rotate_tweens.push(t);
+                } else {
+                    ltrg.tween(t);
+                }
             }
-            if (flags & L_ROT_TO_PATH) ltrg.rotateToPath = true;
+            if (flags & L_ROT_TO_PATH) {
+                var rtp_tween;
+                for (ri = 0, ril = rotate_tweens.length; ri < ril; ri++) {
+                    rtp_tween = Tween[C.T_MRG_ROT_TO_PATH]();
+                    if (rotate_tweens[ri].$band)   rtp_tween.band(rotate_tweens[ri].$band);
+                    if (rotate_tweens[ri].$easing) rtp_tween.easing(rotate_tweens[ri].$easing);
+                    if (rotate_tweens[ri].$value)  rtp_tween.from(rotate_tweens[ri].$value[0])
+                                                            .to(rotate_tweens[ri].$value[1]);
+                    ltrg.tween(rtp_tween);
+                }
+            }
+            rotate_tweens = [];
         }
 
         /** end-action **/

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -284,30 +284,32 @@ Import.branch = function(type, src, all, anim) {
 
         // apply tweens
         if (lsrc[7]) {
-            var rotate_tweens;
+            var rotate_tweens = 0;
+            var first_rotate = 0, last_rotate = Infinity;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
                 if (!t) continue;
                 if ((flags & L_ROT_TO_PATH) && (t.tween_type === C.T_ROTATE)) {
-                    if (!rotate_tweens) rotate_tweens = [];
-                    rotate_tweens.push(t);
-                } else {
-                    ltrg.tween(t);
+                    first_rotate = Math.max(first_rotate, t.$band[0]);
+                    last_rotate = Math.min(last_rotate, t.$band[1]);
+                    rotate_tweens++;
+                }
+                ltrg.tween(t);
+            }
+            if ((flags & L_ROT_TO_PATH) && rotate_tweens) {
+                if (first_rotate > 0) {
+                    ltrg.tween(Tween.rotate().start(0).stop(first_rotate)
+                                             .from(0).to(0));
+                }
+                if (last_rotate < Infinity) {
+                    ltrg.tween(Tween.rotate().start(last_rotate).stop(Infinity)
+                                             .from(0).to(0));
                 }
             }
             if (flags & L_ROT_TO_PATH) {
-                var rtp_tween;
-                for (ri = 0, ril = rotate_tweens.length; ri < ril; ri++) {
-                    rtp_tween = Tween[C.T_MRG_ROT_TO_PATH]();
-                    if (rotate_tweens[ri].$band)   rtp_tween.band(rotate_tweens[ri].$band);
-                    if (rotate_tweens[ri].$easing) rtp_tween.easing(rotate_tweens[ri].$easing);
-                    if (rotate_tweens[ri].$value)  rtp_tween.from(rotate_tweens[ri].$value[0])
-                                                            .to(rotate_tweens[ri].$value[1]);
-                    ltrg.tween(rtp_tween);
-                }
+                ltrg.tween(Tween.rotatetopath().start(0).stop(Infinity));
             }
-            rotate_tweens = [];
         }
 
         /** end-action **/

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -444,7 +444,6 @@ Import.band = function(src) {
  */
 // -> Path
 Import.path = function(src) {
-    return null;
     var path = Import._pathDecode(src[4]);
     if (!path) return;
     return new Path(path);

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -285,15 +285,23 @@ Import.branch = function(type, src, all, anim) {
         // apply tweens
         if (lsrc[7]) {
             var rotate_tweens = 0;
+            var translates = [];
             var first_rotate = 0, last_rotate = Infinity;
+            //var first_translate = 0, last_translate = Infinity;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
                 if (!t) continue;
-                if ((flags & L_ROT_TO_PATH) && (t.tween_type === C.T_ROTATE)) {
-                    first_rotate = Math.max(first_rotate, t.$band[0]);
-                    last_rotate = Math.min(last_rotate, t.$band[1]);
-                    rotate_tweens++;
+                if (flags & L_ROT_TO_PATH) {
+                    if (t.tween_type === C.T_ROTATE) {
+                        first_rotate = Math.max(first_rotate, t.$band[0]);
+                        last_rotate = Math.min(last_rotate, t.$band[1]);
+                        rotate_tweens++;
+                    } else if (t.tween_type === C.T_TRANSLATE) {
+                        //first_translate = Math.max(first_translate, t.$band[0]);
+                        //last_translate = Math.min(last_translate, t.$band[1]);
+                        translates.push(t);
+                    }
                 }
                 ltrg.tween(t);
             }
@@ -307,8 +315,10 @@ Import.branch = function(type, src, all, anim) {
                                              .from(0).to(0));
                 }
             }
-            if (flags & L_ROT_TO_PATH) {
-                ltrg.tween(Tween.rotatetopath().start(0).stop(ltrg.lband[1] - ltrg.lband[0]));
+            if (flags & L_ROT_TO_PATH && translates.length) {
+                for (var i = 0, il = translates.length; i < il; i++) {
+                    ltrg.tween(Tween.rotatetopath().band(translates[i].$band));
+                }
             }
         }
 

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -286,26 +286,26 @@ Import.branch = function(type, src, all, anim) {
         if (lsrc[7]) {
             var rotate_tweens = 0;
             var translates = [];
-            var first_rotate = 0, last_rotate = Infinity;
+            var first_rotate = Infinity, last_rotate = 0;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
                 if (!t) continue;
                 if (flags & L_ROT_TO_PATH) {
                     if (t.tween_type === C.T_ROTATE) {
-                        first_rotate = Math.max(first_rotate, t.$band[0]);
-                        last_rotate = Math.min(last_rotate, t.$band[1]);
+                        first_rotate = Math.min(first_rotate, t.$band[0]);
+                        last_rotate = Math.max(last_rotate, t.$band[1]);
                         rotate_tweens++;
                     }
                 }
                 ltrg.tween(t);
             }
             if ((flags & L_ROT_TO_PATH) && rotate_tweens) {
-                if (first_rotate > 0) {
+                if ((first_rotate > 0) && (first_rotate < Infinity)) {
                     ltrg.tween(Tween.rotate().start(0).stop(first_rotate)
                                              .from(0).to(0));
                 }
-                if (last_rotate < Infinity) {
+                if ((last_rotate > 0) && (last_rotate < Infinity)) {
                     ltrg.tween(Tween.rotate().start(last_rotate).stop(ltrg.lband[1] - ltrg.lband[0])
                                              .from(0).to(0));
                 }

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -284,27 +284,13 @@ Import.branch = function(type, src, all, anim) {
 
         // apply tweens
         if (lsrc[7]) {
-            var translates;
             for (var tweens = lsrc[7], ti = 0, tl = tweens.length;
                  ti < tl; ti++) {
                 var t = Import.tween(tweens[ti]);
                 if (!t) continue;
-                if (t.tween_type === C.T_TRANSLATE) {
-                    if (!translates) translates = [];
-                    translates.push(t);
-                }
                 ltrg.tween(t);
             }
-            if (translates && (flags & L_ROT_TO_PATH)) {
-                var rtp_tween;
-                for (ti = 0, til = translates.length; ti < til; ti++) {
-                    rtp_tween = Tween[C.T_ROT_TO_PATH]();
-                    if (translates[ti].$band) rtp_tween.band(translates[ti].$band);
-                    if (translates[ti].$easing) rtp_tween.easing(translates[ti].$easing);
-                    ltrg.tween(rtp_tween);
-                }
-            }
-            translates = [];
+            if (flags & L_ROT_TO_PATH) ltrg.rotateToPath = true;
         }
 
         /** end-action **/


### PR DESCRIPTION
Now parameter `t` is saved in Translate tween, so it's easy for Orient-to-path tween to have any band it likes, and still be correct. Why haven't I thought about it before?