### PR TITLE
Refactor timing

### DIFF
--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -289,7 +289,6 @@ Animation.prototype.render = function(ctx, dt) {
     ctx.save();
     var zoom = this.zoom;
     this.time.tick(dt);
-    //console.log('Animation', this.getTime());
     if (zoom != 1) {
         ctx.scale(zoom, zoom);
     }

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -324,7 +324,7 @@ Animation.prototype.continue = function() {
 Animation.prototype.jump = function(t) {
     var prev_time = this.getTime();
     this.time.jump(t);
-    if (t !== prev_time) this.goToSceneAt(t);
+    this.goToSceneAt(t);
 };
 
 /**
@@ -343,9 +343,8 @@ Animation.prototype.jumpTo = function(selector) {
     if (elm instanceof Scene) {
         this.goToScene(elm);
     } else {
-        var prev_time = this.getTime();
         this.time.jumpTo(elm);
-        if (this.getTime() !== prev_time) this.goToSceneAt(this.getTime());
+        this.goToSceneAt(this.getTime());
     }
 };
 
@@ -391,11 +390,11 @@ Animation.prototype.goToSceneAt = function(t) {
             this.setCurrentScene(i);
         } else {
             this.setCurrentScene(0);
-            this.currentScene.jumpToStart();
+            this.currentScene.jump(t);
         }
     } else {
         this.setCurrentScene(this.scenes.length - 1);
-        this.currentScene.time.jumpToEnd();
+        this.currentScene.jumpToEnd();
     }
 };
 

--- a/src/anm/animation/animation.js
+++ b/src/anm/animation/animation.js
@@ -65,7 +65,6 @@ function Animation() {
     this.width = undefined;
     this.height = undefined;
     this.zoom = 1.0;
-    this.speed = 1.0;
     this.factor = 1.0;
     this.repeat = false;
     this.meta = {};
@@ -80,6 +79,8 @@ function Animation() {
     this.scenes.push(defaultScene);
     this.currentSceneIdx = 0;
     this.currentScene = this.scenes[this.currentSceneIdx];
+
+    this.endOnLastScene = false;
 }
 
 Animation.DEFAULT_DURATION = 10;
@@ -160,7 +161,10 @@ Animation.prototype.getScenes = function() {
 };
 
 Animation.prototype.toNextScene = function() {
-    if ((this.currentSceneIdx + 1) >= this.scenes.length) return null;
+    if ((this.currentSceneIdx + 1) >= this.scenes.length) {
+        if (this.endOnLastScene) this.time.endNow();
+        return null;
+    }
     this.currentSceneIdx++;
     this.currentScene = this.scenes[this.currentSceneIdx];
     this.currentScene.continue();
@@ -195,10 +199,6 @@ Animation.prototype.replaceScene = function(idx, scene) {
     }
     return this;
 };
-
-/* Animation.prototype.setDuration = function(duration) {
-    this.scene.setDuration(duration);
-} */
 
 /**
  * @method traverse
@@ -361,6 +361,10 @@ Animation.prototype.getTime = function() {
 
 Animation.prototype.setDuration = function(duration) {
     this.time.setDuration(duration);
+};
+
+Animation.prototype.setSpeed = function(speed) {
+    this.time.setSpeed(speed);
 };
 
 Animation.prototype.goToScene = function(scene) {

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -722,9 +722,7 @@ Element.prototype.render = function(ctx, dt) {
 
     this.rendering = true;
 
-    var ltime = (this.parent && this.parent.affectsChildren) // check `affectsChildren` inside `tickParent`?
-                ? this.time.tickParent(dt)
-                : this.time.tick(dt);
+    var ltime = this.tick(dt);
     if (ltime === Element.NO_TIME) return;
 
     var drawMe = this.time.fits() &&
@@ -740,9 +738,7 @@ Element.prototype.render = function(ctx, dt) {
         var mask_ltime;
 
         if (mask) {
-            mask_ltime = (mask.parent && mask.parent.affectsChildren) // check `affectsChildren` inside `tickParent`?
-                         ? mask.time.tickParent(dt)
-                         : mask.time.tick(dt);
+            mask_ltime = mask.tick(dt);
 
             // FIXME: move this chain completely into one method, or,
             //        which is even better, make all these checks to be modifiers
@@ -841,6 +837,16 @@ Element.prototype.render = function(ctx, dt) {
     this.__postRender();
     this.rendering = false;
     return this;
+};
+
+Element.prototype.tick = function(dt) {
+    if (!this.parent && this.scene && this.scene.affectsChildren) {
+        return this.time.tickRelative(this.scene.time, dt);
+    } else if (this.parent && this.parent.affectsChildren) {
+        return this.time.tickRelative(this.parent.time, dt);
+    } else {
+        return this.time.tick(dt);
+    }
 };
 
 /**

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -1105,7 +1105,19 @@ Element.prototype.mode = function(mode, nrep) {
  * @return {anm.Element} itself
  */
 Element.prototype.jump = function(t) {
+    var delta = t - this.getTime();
     this.time.jump(t);
+    this.each(function(child) {
+        child.jumpDelta(delta);
+    });
+    return this;
+};
+
+Element.prototype.jumpDelta = function(dt) {
+    this.time.jumpDelta(dt);
+    this.each(function(child) {
+        child.jumpDelta(dt);
+    });
     return this;
 };
 
@@ -1126,6 +1138,7 @@ Element.prototype.jump = function(t) {
 Element.prototype.jumpTo = function(element) {
     var elm = is.str(selector) ? this.find(selector) : selector;
     if (!elm) return;
+    // var delta = this.time.getLastDelta (?)
     this.time.jumpTo(elm);
     return this;
 };

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -1105,19 +1105,7 @@ Element.prototype.mode = function(mode, nrep) {
  * @return {anm.Element} itself
  */
 Element.prototype.jump = function(t) {
-    var delta = t - this.getTime();
     this.time.jump(t);
-    this.each(function(child) {
-        child.jumpDelta(delta);
-    });
-    return this;
-};
-
-Element.prototype.jumpDelta = function(dt) {
-    this.time.jumpDelta(dt);
-    this.each(function(child) {
-        child.jumpDelta(dt);
-    });
     return this;
 };
 

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -2646,6 +2646,7 @@ Element.prototype.addDebugRender = function() {
     this.paint(Render.p_drawBounds);
     this.paint(Render.p_drawReg);
     this.paint(Render.p_drawName);
+    this.paint(Render.p_drawTime);
     this.paint(Render.p_drawMPath);
 };
 

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -729,7 +729,6 @@ Element.prototype.render = function(ctx, dt) {
                  this.modifiers(ltime, dt) &&
                  this.visible; // modifiers should be applied even if element isn't visible
     if (drawMe) {
-        //console.log('Element', this.name, this.getTime());
         ctx.save();
 
         var mask = this.$mask,

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -23,8 +23,13 @@ function Scene(anim, name, duration) {
 }
 
 Scene.prototype.render = function(ctx, dt) {
+    if ((this.getTime() < 1) && ((this.getTime() + dt) > 1)) {
+        if (this.__once) debugger;
+        this.__once = true;
+        console.log('HOP!');
+    }
     this.time.tick(dt);
-    //console.log('Scene', this.name, this.getTime());
+    console.log('Scene', this.name, this.getTime());
     if (this.time.fits()) {
         this.each(function(child) {
             child.render(ctx, dt);

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -156,9 +156,18 @@ Scene.prototype.pause = function() {
 Scene.prototype.stop = Scene.prototype.pause; // FIXME
 
 Scene.prototype.jump = function(t) {
+    var delta = t - this.getTime();
     this.time.jump(t);
     this.each(function(child) {
-        child.time.jump(t); // all scenes start at t==0, so it's safe not to subtract start
+        child.jumpDelta(delta);
+    });
+    return this;
+};
+
+Scene.prototype.jumpDelta = function(dt) {
+    this.time.jumpDelta(dt);
+    this.each(function(child) {
+        child.jumpDelta(dt);
     });
     return this;
 };
@@ -167,7 +176,7 @@ Scene.prototype.jumpTo = function(elm) {
     this.time.jumpTo(elm);
     var new_t = this.time.pos;
     this.each(function(child) {
-        child.time.jump(new_t); // all scenes start at t==0, so it's safe not to subtract start
+        child.time.jump(new_t);
     });
     return this;
 };

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -23,9 +23,10 @@ function Scene(anim, name, duration) {
 }
 
 Scene.prototype.render = function(ctx, dt) {
-    if ((this.getTime() < 1) && ((this.getTime() + dt) > 1)) {
-        if (this.__once) debugger;
-        this.__once = true;
+    if ((this.getTime() < 3) && ((this.getTime() + dt) > 3)) {
+        if (this.__times === 1) debugger;
+        if (!is.defined(this.__times)) this.__times = 0;
+        this.__times++;
         console.log('HOP!');
     }
     this.time.tick(dt);

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -23,14 +23,7 @@ function Scene(anim, name, duration) {
 }
 
 Scene.prototype.render = function(ctx, dt) {
-    if ((this.getTime() < 3) && ((this.getTime() + dt) > 3)) {
-        /*if (this.__times === 1) *///debugger;
-        //if (!is.defined(this.__times))* this.__times = 0;
-        //this.__times++;
-        console.log('HOP!');
-    }
     this.time.tick(dt);
-    console.log('Scene', this.name, this.getTime());
     if (this.time.fits()) {
         this.each(function(child) {
             child.render(ctx, dt);

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -156,44 +156,22 @@ Scene.prototype.pause = function() {
 Scene.prototype.stop = Scene.prototype.pause; // FIXME
 
 Scene.prototype.jump = function(t) {
-    var delta = t - this.getTime();
     this.time.jump(t);
-    this.each(function(child) {
-        child.jumpDelta(delta);
-    });
-    return this;
-};
-
-Scene.prototype.jumpDelta = function(dt) {
-    this.time.jumpDelta(dt);
-    this.each(function(child) {
-        child.jumpDelta(dt);
-    });
     return this;
 };
 
 Scene.prototype.jumpTo = function(elm) {
-    var before = this.getTime();
     this.time.jumpTo(elm);
-    var delta = this.getTime() - before;
-    this.each(function(child) {
-        child.jumpDelta(delta);
-    });
     return this;
 };
 
 Scene.prototype.jumpToStart = function() {
-    this.jump(0);
+    this.time.jumpToStart(0);
     return this;
 };
 
 Scene.prototype.jumpToEnd = function() {
-    var before = this.getTime();
     this.time.jumpToEnd();
-    var delta = this.getTime() - before;
-    this.each(function(child) {
-        child.jumpDelta(delta);
-    });
     return this;
 };
 

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -24,9 +24,9 @@ function Scene(anim, name, duration) {
 
 Scene.prototype.render = function(ctx, dt) {
     if ((this.getTime() < 3) && ((this.getTime() + dt) > 3)) {
-        if (this.__times === 1) debugger;
-        if (!is.defined(this.__times)) this.__times = 0;
-        this.__times++;
+        /*if (this.__times === 1) *///debugger;
+        //if (!is.defined(this.__times))* this.__times = 0;
+        //this.__times++;
         console.log('HOP!');
     }
     this.time.tick(dt);

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -16,6 +16,8 @@ function Scene(anim, name, duration) {
     this.time = new Timeline(this);
     this.time.setDuration(is.num(duration) ? duration : Infinity);
 
+    this.affectsChildren = true;
+
     this.children = [];
     this.hash = {};
 }

--- a/src/anm/animation/scene.js
+++ b/src/anm/animation/scene.js
@@ -173,16 +173,28 @@ Scene.prototype.jumpDelta = function(dt) {
 };
 
 Scene.prototype.jumpTo = function(elm) {
+    var before = this.getTime();
     this.time.jumpTo(elm);
-    var new_t = this.time.pos;
+    var delta = this.getTime() - before;
     this.each(function(child) {
-        child.time.jump(new_t);
+        child.jumpDelta(delta);
     });
     return this;
 };
 
 Scene.prototype.jumpToStart = function() {
     this.jump(0);
+    return this;
+};
+
+Scene.prototype.jumpToEnd = function() {
+    var before = this.getTime();
+    this.time.jumpToEnd();
+    var delta = this.getTime() - before;
+    this.each(function(child) {
+        child.jumpDelta(delta);
+    });
+    return this;
 };
 
 Scene.prototype.jumpAt = function(at, t) {

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -23,7 +23,6 @@ function Timeline(owner) {
     this.pos = -this.start || 0;
     this.actualPos = -this.start || 0;
     this.easing = null;
-    this.actionsPos = 0; // -1?
     this.speed = 1;
 
     this.passedStart = false;
@@ -36,7 +35,6 @@ Timeline.prototype.reset = function() {
     this.paused = false;
     this.pos = -this.start;
     this.actualPos = -this.start;
-    this.actionsPos = 0;
     this.passedStart = false;
     this.passedEnd = false;
 };
@@ -45,7 +43,6 @@ Timeline.prototype.addAction = function(t, f) {
     var actions = this.actions;
     var i = 0;
     for (var il = this.actions.length; (i < il) && (actions[i].time < t); i++) { };
-    //this.actionsPos = 0;
     this.actions.splice(i, 0, { time: t, func: f });
 };
 
@@ -244,25 +241,23 @@ Timeline.prototype.fireMessageAt = function(at, message) {
 };
 
 Timeline.prototype._performActionsBetween = function(prev, next, dt) {
+    if ((prev <= 1) && (next >= 1)) console.log(this.owner.name, 'POOOP');
     if (!this.actions.length) return;
-    if (next < prev) { this.actionsPos = 0; }
-    var curAction = this.actions[this.actionsPos];
+    var actionsPos = 0;
+    var curAction = this.actions[actionsPos];
     // scroll to current time (this.time) forward first, if we're not there already
     while (curAction && (this.actionsPos < this.actions.length) &&
            (curAction.time < prev)) {
-        this.actionsPos++;
-        curAction = this.actions[this.actionsPos];
+        actionsPos++; curAction = this.actions[actionsPos];
     }
     // then perform everything before `next` time
-    while (curAction && (this.actionsPos < this.actions.length) &&
+    while (curAction && (actionsPos < this.actions.length) &&
            (curAction.time <= next) &&
            ((curAction.time > prev) ||
             ((dt > 0) && (curAction.time == prev)))) {
         curAction.func(next);
-        this.actionsPos++;
-        curAction = this.actions[this.actionsPos];
+        actionsPos++; curAction = this.actions[actionsPos];
     }
-    if (this.actionsPos === this.actions.length) { this.actionsPos = 0; }
 }
 
 Timeline.prototype.clone = function(owner) {

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -200,7 +200,7 @@ Timeline.prototype.countinueAt = function(at) {
 };
 
 Timeline.prototype.jump = function(t) {
-    console.log(this.owner.name || 'Animation', 'jump', this.pos, '->', t);
+    //console.log(this.owner.name || 'Animation', 'jump', this.pos, '->', t);
     if (t !== this.pos) this._scrollActionsTo(t);
     this.pos = t; this.fire(C.X_JUMP, t);
 };

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -209,10 +209,6 @@ Timeline.prototype.jump = function(t) {
     this.pos = t; this.fire(C.X_JUMP, t);
 };
 
-Timeline.prototype.jumpDelta = function(t) {
-    this.jump(this.pos + t);
-};
-
 Timeline.prototype.jumpAt = function(at, t) {
     var me = this; this.addAction(at, function() { me.jump(t); });
 };

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -209,6 +209,10 @@ Timeline.prototype.jump = function(t) {
     this.pos = t; this.fire(C.X_JUMP, t);
 };
 
+Timeline.prototype.jumpDelta = function(t) {
+    this.jump(this.pos + t);
+};
+
 Timeline.prototype.jumpAt = function(at, t) {
     var me = this; this.addAction(at, function() { me.jump(t); });
 };

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -193,7 +193,6 @@ Timeline.prototype.countinueAt = function(at) {
 };
 
 Timeline.prototype.jump = function(t) {
-    console.log(new Date(), this.owner.name || 'Animation', 'jump', this.pos, '->', t);
     this.pos = t; this.fire(C.X_JUMP, t);
 };
 
@@ -240,7 +239,6 @@ Timeline.prototype.fireMessageAt = function(at, message) {
 };
 
 Timeline.prototype._performActionsBetween = function(prev, next, dt) {
-    if ((prev <= 1) && (next >= 1)) console.log(this.owner.name, 'POOOP');
     if (!this.actions.length) return;
     var actionsPos = 0;
     var curAction = this.actions[actionsPos];

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -246,7 +246,7 @@ Timeline.prototype._performActionsBetween = function(prev, next, dt) {
     var actionsPos = 0;
     var curAction = this.actions[actionsPos];
     // scroll to current time (this.time) forward first, if we're not there already
-    while (curAction && (this.actionsPos < this.actions.length) &&
+    while (curAction && (actionsPos < this.actions.length) &&
            (curAction.time < prev)) {
         actionsPos++; curAction = this.actions[actionsPos];
     }

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -23,7 +23,7 @@ function Timeline(owner) {
     this.pos = -this.start || 0;
     this.actualPos = -this.start || 0;
     this.easing = null;
-    this.actionsPos = 0;
+    this.actionsPos = 0; // -1?
     this.speed = 1;
 
     this.passedStart = false;
@@ -107,15 +107,11 @@ Timeline.prototype.tick = function(dt) {
     return this.pos;
 };
 
-Timeline.prototype.tickParent = function(dt) {
-    // this could be replaced with subscribing parent to children's
-    // X_ITER and resetting their timeline
-    if (!this.owner.parent) { return this.tick(dt); };
-    var parent_time = this.owner.parent.time;
-    if (!parent_time || !is.defined(parent_time.pos)) return undefined;
-    this.pos = parent_time.pos - this.start - dt;
+Timeline.prototype.tickRelative = function(other, dt) {
+    if (!other || !is.defined(other.pos)) { /*this.endNow();*/ return undefined; }
+    this.pos = other.pos - this.start - dt;
     this.actualPos = this.pos;
-    // this._scrollActionsTo?
+    // this._scrollActionsTo? // _performActionsUpTo?
     return this.tick(dt);
 };
 
@@ -254,7 +250,7 @@ Timeline.prototype.fireMessageAt = function(at, message) {
 Timeline.prototype._performActionsUpTo = function(next, prev, dt) {
     if (!this.actions.length) return;
     var curAction = this.actions[this.actionsPos];
-    // scroll to current time (this.time) first, if we're not there already
+    // scroll to current time (this.time) forward first, if we're not there already
     while (curAction && (this.actionsPos < this.actions.length) &&
            (curAction.time < prev)) {
         this.actionsPos++;
@@ -273,6 +269,7 @@ Timeline.prototype._performActionsUpTo = function(next, prev, dt) {
 }
 
 Timeline.prototype._scrollActionsTo = function(time) {
+    if (!this.actions.length) return;
     var curAction = this.actions[this.actionsPos];
     while (curAction && (this.actionsPos < this.actions.length) &&
            (curAction.time < time)) {

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -207,7 +207,6 @@ Timeline.prototype.jump = function(t) {
     console.log(this.owner.name || 'Animation', 'jump', this.pos, '->', t);
     if (t !== this.pos) this._scrollActionsTo(t);
     this.pos = t; this.fire(C.X_JUMP, t);
-    console.log(this.owner.name || 'Animation', 'successful jump to ', this.pos);
 };
 
 Timeline.prototype.jumpAt = function(at, t) {

--- a/src/anm/animation/timeline.js
+++ b/src/anm/animation/timeline.js
@@ -55,8 +55,7 @@ Timeline.prototype.tick = function(dt) {
 
     if (is.finite(this.duration) && (next > this.duration)) {
         if (this.mode === C.R_ONCE) {
-            next = this.duration;
-            this.passedEnd = true;
+            //next = undefined; let it be higher than duration
         } else if (this.mode === C.R_STAY) {
             var wasPaused = this.paused;
             this.paused = true;

--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -349,6 +349,10 @@ Audio.prototype.connect = function(element, anim) {
     element.on(C.X_END, function() {
         me.stopIfNotMaster();
     });
+    element.on(C.X_JUMP, function() {
+        me.stopIfNotMaster();
+        me.play.apply(me, arguments);
+    });
     var stop = function() {
         me.stop();
     };

--- a/src/anm/render.js
+++ b/src/anm/render.js
@@ -49,10 +49,6 @@ function r_loop(ctx, player, anim, before, after, before_render, after_render) {
     var fps = 0;
     if (player.__rsec === 0) player.__rsec = msec;
 
-    /*console.log('msec', msec, 'sec', sec,
-                '__rsec', player.__rsec,
-                'msec - __rsec', (msec - player.__rsec),
-                '__redraws', player.__redraws);*/
     if ((msec - player.__rsec) >= 1000) {
         fps = player.__redraws;
         player.fps = fps;

--- a/src/anm/render.js
+++ b/src/anm/render.js
@@ -256,6 +256,15 @@ Render.p_drawName = new Painter(function(ctx, name) {
     ctx.restore();
 }, C.PNT_DEBUG);
 
+Render.p_drawTime = new Painter(function(ctx, time) {
+    if (!(time = time || this.time.getLastPosition())) return;
+    ctx.save();
+    ctx.fillStyle = '#600';
+    ctx.font = '10px sans-serif';
+    ctx.fillText(Math.round(time * 1000) / 1000, 0, 20);
+    ctx.restore();
+}, C.PNT_DEBUG);
+
 Render.p_drawMPath = new Painter(function(ctx, mPath) {
     if (!(mPath = mPath || this.$mpath)) return;
     ctx.save();

--- a/src/anm/render.js
+++ b/src/anm/render.js
@@ -48,12 +48,17 @@ function r_loop(ctx, player, anim, before, after, before_render, after_render) {
 
     var fps = 0;
     if (player.__rsec === 0) player.__rsec = msec;
+
+    /*console.log('msec', msec, 'sec', sec,
+                '__rsec', player.__rsec,
+                'msec - __rsec', (msec - player.__rsec),
+                '__redraws', player.__redraws);*/
     if ((msec - player.__rsec) >= 1000) {
         fps = player.__redraws;
+        player.fps = fps;
         player.__rsec = msec;
         player.__redraws = 0;
     }
-    player.fps = fps;
     player.__redraws++;
 
     r_next(dt, ctx, anim,
@@ -62,7 +67,7 @@ function r_loop(ctx, player, anim, before, after, before_render, after_render) {
 
     // show fps
     if (player.debug) {
-        r_fps(ctx, fps, time);
+        r_fps(ctx, player.fps, time);
     }
 
     if (after) {

--- a/src/import/animatron-importer.js
+++ b/src/import/animatron-importer.js
@@ -83,7 +83,16 @@ Import.project = function(prj) {
     root.fonts = Import.fonts(prj);
     Import.root = root;
     Import.anim(prj, root); // will inject all required properties directly in animation object
-    if (prj.meta.duration) root.setDuration(prj.meta.duration);
+
+    // some additional configuration
+    if (prj.meta.duration && !prj.anim.script) {
+        root.setDuration(prj.meta.duration);
+    }
+    if (prj.anim.script) {
+        root.actions = prj.anim.script;
+        root.setDuration(Infinity);
+        root.endOnLastScene = true;
+    }
 
     Import._paths = prj.anim.paths;
     Import._path_cache = new ValueCache();
@@ -141,9 +150,8 @@ Import.anim = function(prj, trg) {
     trg.height = a.dimension ? Math.floor(a.dimension[1]): undefined;
     trg.bgfill = a.background ? Import.fill(a.background) : undefined;
     trg.zoom = a.zoom || 1.0;
-    trg.speed = a.speed || 1.0;
+    trg.setSpeed(a.speed || 1.0);
     if (a.loop && ((a.loop === true) || (a.loop === 'true'))) trg.repeat = true;
-    if (prj.anim.script) trg.actions = prj.anim.script;
 };
 
 var TYPE_UNKNOWN =  0,


### PR DESCRIPTION
Better rethink of the navigation in time. 
Now `Scene` also may `affectChildren` time, as well as any `Element` (and they do by default).
Only a `Clip`, when imported from Animatron, do not affects children. 
So by default everything regarding time stops and jumps emulates Flash behaviour.

If Animation is infinite, it could end when last scene finished (and if it has some loop-jump inside, it never ends).

Fix for FPS in debug mode, plus display local time nicely for every element or scene, helps truly a lot!

Temporary drawback: Loops through all actions in a frame for the moment, if there are some, but this guarantees that all jumps in any direction really work. I could find better algorithm and/or improve searching for the fitting action later.