### PR TITLE
Use child duration to calculate switch position

### DIFF
--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -715,7 +715,6 @@ Element.prototype.tick = function(dt) {
                     if (this.justSwitched) child.timeline.reset();
                     var newPos = (this.getTime() - this.switchBand[0]) % child.timeline.getDuration();
                     var childTime = child.timeline.tickRelativeToPosition(newPos, dt);
-                    //console.log('switch band', this.switchBand, 'child', child.name, 'child duration', child.timeline.getDuration(), 't', this.getTime(), 'calculated child t', newPos, 'result child t', childTime);
                     if (child.timeline.isActive()) child.modifiers(childTime, dt);
                 }
             }.bind(this));

--- a/src/anm/animation/element.js
+++ b/src/anm/animation/element.js
@@ -712,11 +712,11 @@ Element.prototype.tick = function(dt) {
         if (this.hasSwitch) {
             this.each(function(child) {
                 if (child.name == this.switch) {
-                    if (this.justSwitched/* || ((this.getTime() - this.switchBand[0]) > child.timeline.getDuration())*/) child.timeline.reset();
-                    //console.log('before', this.switchBand, 'parent', this.name, this.getTime(), 'child', child.name, child.getTime(), 'dt', dt);
-                    var childTime = child.timeline.tickRelativeToPosition(this.getTime() - this.switchBand[0], dt);
+                    if (this.justSwitched) child.timeline.reset();
+                    var newPos = (this.getTime() - this.switchBand[0]) % child.timeline.getDuration();
+                    var childTime = child.timeline.tickRelativeToPosition(newPos, dt);
+                    //console.log('switch band', this.switchBand, 'child', child.name, 'child duration', child.timeline.getDuration(), 't', this.getTime(), 'calculated child t', newPos, 'result child t', childTime);
                     if (child.timeline.isActive()) child.modifiers(childTime, dt);
-                    //console.log('after', this.switchBand, 'parent', this.name, this.getTime(), 'child', child.name, child.getTime(), 'dt', dt);
                 }
             }.bind(this));
         } else {


### PR DESCRIPTION
@skavish This one could work better, _but_ it requires clip children to be exported with appropriate bands.

Editor currently works like this:

```
Clip:     ♦--Rect--◇------♦---Circle---♦--Rect--◇--------◇----♦
  Rect:   ♦-trans.-♦--no-tweens----------------∞ (Rect band is exported as [0, Infinity])
  Circle: ♦--rotate----♦--no-tweens----------------∞ (Circle child band exported as [0, Infinity])
```

`◇` is the place where `Rect` time is reset to `0` in Editor. I need this band to be able to do the same in Player.

