### PR TITLE
don't add audio extension if already present

### DIFF
--- a/src/anm/media/audio.js
+++ b/src/anm/media/audio.js
@@ -47,7 +47,7 @@ var audioContext = getAudioContext();
  * @class anm.Audio
  */
 function Audio(url) {
-    this.url = url + audioExt;
+    this.url = /\.\w+$/i.test(url) ? url : url + audioExt;
     this.ready = false;
     this.active = false;
     this.playing = false;


### PR DESCRIPTION
@shamansir @skavish 
not sure, but it's probably better to check like this `\.(mp3|ogg|wav)$`